### PR TITLE
Add upstash-mcp plugin entry for mcp-server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,15 @@
     {
       "name": "upstash",
       "source": "./",
-      "description": "Agent skills and MCP server for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box."
+      "description": "Agent skills for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box."
+    },
+    {
+      "name": "upstash-mcp",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/upstash/mcp-server.git"
+      },
+      "description": "MCP server for managing & debugging Upstash Redis, QStash, Workflow and Box"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `upstash-mcp` plugin entry pointing to `upstash/mcp-server` repo
- Fixes existing `upstash` plugin description to remove incorrect "MCP server" mention

Companion PR: https://github.com/upstash/mcp-server/pull/15