### PR TITLE
Fix upstash plugin description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "upstash",
       "source": "./",
-      "description": "Agent skills and MCP server for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box."
+      "description": "Agent skills for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Removes incorrect "MCP server" mention from the upstash plugin description
- The plugin provides agent skills, not an MCP server