### PR TITLE
DX-2595: document qstash auto dev server in skill

### DIFF
--- a/skills/upstash-qstash-js/SKILL.md
+++ b/skills/upstash-qstash-js/SKILL.md
@@ -48,6 +48,7 @@ For fundamental QStash operations, see:
 - [Schedules](fundamentals/schedules.md)
 - [Queues and Flow Control](fundamentals/queues-and-flow-control.md)
 - [URL Groups](fundamentals/url-groups.md)
+- [Local Development](fundamentals/local-development.md) — automatic dev server via `devMode: true`
 
 For verifying incoming messages:
 

--- a/skills/upstash-qstash-js/fundamentals/local-development.md
+++ b/skills/upstash-qstash-js/fundamentals/local-development.md
@@ -1,0 +1,106 @@
+# Local Development
+
+Use the QStash dev server to test publishing and signature verification end-to-end on your machine — no public tunnel, no real QStash account, no real signing keys.
+
+## Automatic dev server (recommended)
+
+Pass `devMode: true` to the `Client` (and the matching verifier). The SDK will download the QStash CLI binary, start it, and wire credentials for you.
+
+```typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ devMode: true });
+
+await client.publishJSON({
+  url: "https://example.com/webhook",
+  body: { hello: "world" },
+});
+```
+
+When `devMode` is on:
+
+- The SDK downloads the latest `qstash` binary on first use, caches it under the OS cache directory, and reuses it across projects.
+- Spawns the dev server on port `8080` (override via `QSTASH_DEV_PORT`).
+- Reuses an already-running server on the configured port instead of spawning a duplicate.
+- Injects deterministic dev `baseUrl`, `token`, and signing keys. **Any explicit `token` / `baseUrl` / signing keys you pass are ignored** (a warning is printed). To use real credentials, set `devMode: false`.
+- Forwards dev server logs to stdout/stderr with a dim `[QStash CLI]` prefix.
+- No-ops in production (`NODE_ENV=production`), during `next build`, and in browser/edge runtimes.
+
+### Environment variable
+
+Instead of hard-coding `devMode: true`, leave the option unset and toggle via env:
+
+```bash
+QSTASH_DEV=true       # or "1"
+QSTASH_DEV_PORT=8080  # optional, default 8080
+```
+
+The resolution order is: explicit `devMode` boolean > `QSTASH_DEV` env var > off. Use this so production code never accidentally turns the dev server on.
+
+### Verifying signatures in dev
+
+The receiving side also needs `devMode: true` so it verifies against the dev server's deterministic signing keys instead of your real ones.
+
+```typescript
+import { Receiver } from "@upstash/qstash";
+
+const receiver = new Receiver({ devMode: true });
+
+await receiver.verify({
+  signature: request.headers.get("upstash-signature")!,
+  body: await request.text(),
+});
+```
+
+For Next.js, the wrappers accept the same flag:
+
+```typescript
+// app/api/webhook/route.ts
+import { verifySignatureAppRouter } from "@upstash/qstash/nextjs";
+
+export const POST = verifySignatureAppRouter(
+  async (request) => new Response("ok"),
+  { devMode: true }
+);
+```
+
+### Next.js: starting the server before edge routes
+
+Edge runtimes cannot spawn child processes. If a route in the Edge Runtime is the first thing to use QStash, the SDK can only check whether the server is reachable — it cannot start it. Call `registerQStashDev()` from `instrumentation.ts` to spawn the server during Next.js startup, before any request hits:
+
+```typescript
+// instrumentation.ts
+import { registerQStashDev } from "@upstash/qstash/nextjs";
+
+export function register() {
+  registerQStashDev();
+}
+```
+
+`registerQStashDev` is itself a no-op in production and during `next build`.
+
+### Common pitfalls
+
+- **Passing `token` alongside `devMode: true`** — the explicit token is ignored and you get a console warning. Drop the `token` field, or set `devMode: false` to use it.
+- **Hitting build-time errors in `next build`** — if a route module is evaluated at build time and instantiates the `Client`, mark the route `export const dynamic = "force-dynamic"` so it isn't pre-rendered.
+- **Port 8080 already in use** — the SDK errors with a clear message; either stop the other process or set `QSTASH_DEV_PORT` to a free port (matched on both client and receiver sides).
+- **Calling QStash from an edge route without `instrumentation.ts`** — the edge runtime can't spawn the binary. Either move the call to a Node-runtime route or wire `registerQStashDev()` as shown above.
+
+## Manual dev server
+
+If you cannot use the automatic flow (non-Node runtime, CI without internet, custom binary), run the CLI yourself:
+
+```bash
+npx @upstash/qstash-cli dev
+```
+
+Then construct the client with the printed dev credentials explicitly and **leave `devMode` unset/false**:
+
+```typescript
+const client = new Client({
+  baseUrl: "http://127.0.0.1:8080",
+  token: "eyJVc2VySUQiOiJkZWZhdWx0VXNlciIsIlBhc3N3b3JkIjoiZGVmYXVsdFBhc3N3b3JkIn0=",
+});
+```
+
+See the [Local Development docs](https://upstash.com/docs/qstash/howto/local-development) for the full list of test users and CLI options.

--- a/skills/upstash-workflow-js/SKILL.md
+++ b/skills/upstash-workflow-js/SKILL.md
@@ -50,7 +50,7 @@ These files contain the full documentation. Use them for details, patterns, and 
   - **features/wait-for-event** – Notify and wait-for-event patterns.
   - **features/webhooks** – Webhook creation and consumption.
 - how to:
-  - **how-to/local-dev** – Local QStash dev server and tunneling.
+  - **how-to/local-dev** – Local QStash dev server (auto via `QSTASH_DEV=true`) and tunneling.
   - **how-to/realtime** – Realtime and human‑in‑the‑loop workflows.
   - **how-to/migrations** – Migrating workflows safely.
   - **how-to/middleware** – Adding middleware to workflows.

--- a/skills/upstash-workflow-js/how-to/local-dev.md
+++ b/skills/upstash-workflow-js/how-to/local-dev.md
@@ -6,14 +6,63 @@ This documentation explains how to run Upstash Workflow locally using the QStash
 
 Upstash Workflow uses Upstash QStash under the hood. During development you can:
 
-- Run a **local QStash development server** to simulate workflow behavior entirely offline.
+- Use the **automatic dev server** by setting `QSTASH_DEV=true`. The SDK downloads the QStash CLI binary, spawns the server, and verifies signatures with its dev keys. No tokens or signing keys required.
+- Run a **local QStash development server** manually via the CLI and wire credentials yourself.
 - Optionally expose your local server using **ngrok** if you want to test with the production QStash.
 
-Both approaches require updating environment variables and ensuring your workflow trigger URLs correctly reference your local or tunnel address.
+---
+
+## Automatic dev server (recommended)
+
+Set `QSTASH_DEV=true` in your environment and that's it. Workflow's `serve()` endpoint and the `Client` both auto-detect it:
+
+```
+QSTASH_DEV=true
+```
+
+```ts
+// app/api/workflow/route.ts
+import { serve } from "@upstash/workflow/nextjs";
+
+export const { POST } = serve(async (context) => {
+  await context.run("step-1", () => console.log("running locally"));
+});
+```
+
+```ts
+import { Client } from "@upstash/workflow";
+
+const client = new Client({ token: process.env.QSTASH_TOKEN ?? "" });
+
+await client.trigger({
+  url: "http://localhost:3000/api/workflow",
+});
+```
+
+When `QSTASH_DEV=true`:
+
+- The underlying `@upstash/qstash` client downloads the QStash CLI binary on first use, spawns the dev server on port `8080` (override via `QSTASH_DEV_PORT`), and reuses an already-running server on that port instead of spawning a duplicate.
+- `serve()` builds a dev-mode `Receiver` internally, so signature verification works against the dev server's deterministic signing keys with no real credentials.
+- It's a no-op in production (`NODE_ENV=production`), during `next build`, and in browser/edge runtimes.
+
+**Next.js edge routes:** the edge runtime cannot spawn child processes. If your workflow route runs on the Edge Runtime, call `registerQStashDev()` from `instrumentation.ts` so the binary starts at Next.js boot:
+
+```ts
+// instrumentation.ts
+import { registerQStashDev } from "@upstash/qstash/nextjs";
+
+export function register() {
+  registerQStashDev();
+}
+```
+
+See the [QStash Local Development skill](../../upstash-qstash-js/fundamentals/local-development.md) for the full reference, including pitfalls and CLI options.
 
 ---
 
 ## 1. Start the QStash Local Development Server
+
+If you'd rather manage the dev server yourself instead of using the automatic flow above, run the CLI manually.
 
 Use the QStash CLI:
 

--- a/skills/upstash/upstash-qstash-js/fundamentals/local-development.md
+++ b/skills/upstash/upstash-qstash-js/fundamentals/local-development.md
@@ -1,0 +1,106 @@
+# Local Development
+
+Use the QStash dev server to test publishing and signature verification end-to-end on your machine — no public tunnel, no real QStash account, no real signing keys.
+
+## Automatic dev server (recommended)
+
+Pass `devMode: true` to the `Client` (and the matching verifier). The SDK will download the QStash CLI binary, start it, and wire credentials for you.
+
+```typescript
+import { Client } from "@upstash/qstash";
+
+const client = new Client({ devMode: true });
+
+await client.publishJSON({
+  url: "https://example.com/webhook",
+  body: { hello: "world" },
+});
+```
+
+When `devMode` is on:
+
+- The SDK downloads the latest `qstash` binary on first use, caches it under the OS cache directory, and reuses it across projects.
+- Spawns the dev server on port `8080` (override via `QSTASH_DEV_PORT`).
+- Reuses an already-running server on the configured port instead of spawning a duplicate.
+- Injects deterministic dev `baseUrl`, `token`, and signing keys. **Any explicit `token` / `baseUrl` / signing keys you pass are ignored** (a warning is printed). To use real credentials, set `devMode: false`.
+- Forwards dev server logs to stdout/stderr with a dim `[QStash CLI]` prefix.
+- No-ops in production (`NODE_ENV=production`), during `next build`, and in browser/edge runtimes.
+
+### Environment variable
+
+Instead of hard-coding `devMode: true`, leave the option unset and toggle via env:
+
+```bash
+QSTASH_DEV=true       # or "1"
+QSTASH_DEV_PORT=8080  # optional, default 8080
+```
+
+The resolution order is: explicit `devMode` boolean > `QSTASH_DEV` env var > off. Use this so production code never accidentally turns the dev server on.
+
+### Verifying signatures in dev
+
+The receiving side also needs `devMode: true` so it verifies against the dev server's deterministic signing keys instead of your real ones.
+
+```typescript
+import { Receiver } from "@upstash/qstash";
+
+const receiver = new Receiver({ devMode: true });
+
+await receiver.verify({
+  signature: request.headers.get("upstash-signature")!,
+  body: await request.text(),
+});
+```
+
+For Next.js, the wrappers accept the same flag:
+
+```typescript
+// app/api/webhook/route.ts
+import { verifySignatureAppRouter } from "@upstash/qstash/nextjs";
+
+export const POST = verifySignatureAppRouter(
+  async (request) => new Response("ok"),
+  { devMode: true }
+);
+```
+
+### Next.js: starting the server before edge routes
+
+Edge runtimes cannot spawn child processes. If a route in the Edge Runtime is the first thing to use QStash, the SDK can only check whether the server is reachable — it cannot start it. Call `registerQStashDev()` from `instrumentation.ts` to spawn the server during Next.js startup, before any request hits:
+
+```typescript
+// instrumentation.ts
+import { registerQStashDev } from "@upstash/qstash/nextjs";
+
+export function register() {
+  registerQStashDev();
+}
+```
+
+`registerQStashDev` is itself a no-op in production and during `next build`.
+
+### Common pitfalls
+
+- **Passing `token` alongside `devMode: true`** — the explicit token is ignored and you get a console warning. Drop the `token` field, or set `devMode: false` to use it.
+- **Hitting build-time errors in `next build`** — if a route module is evaluated at build time and instantiates the `Client`, mark the route `export const dynamic = "force-dynamic"` so it isn't pre-rendered.
+- **Port 8080 already in use** — the SDK errors with a clear message; either stop the other process or set `QSTASH_DEV_PORT` to a free port (matched on both client and receiver sides).
+- **Calling QStash from an edge route without `instrumentation.ts`** — the edge runtime can't spawn the binary. Either move the call to a Node-runtime route or wire `registerQStashDev()` as shown above.
+
+## Manual dev server
+
+If you cannot use the automatic flow (non-Node runtime, CI without internet, custom binary), run the CLI yourself:
+
+```bash
+npx @upstash/qstash-cli dev
+```
+
+Then construct the client with the printed dev credentials explicitly and **leave `devMode` unset/false**:
+
+```typescript
+const client = new Client({
+  baseUrl: "http://127.0.0.1:8080",
+  token: "eyJVc2VySUQiOiJkZWZhdWx0VXNlciIsIlBhc3N3b3JkIjoiZGVmYXVsdFBhc3N3b3JkIn0=",
+});
+```
+
+See the [Local Development docs](https://upstash.com/docs/qstash/howto/local-development) for the full list of test users and CLI options.

--- a/skills/upstash/upstash-qstash-js/overview.md
+++ b/skills/upstash/upstash-qstash-js/overview.md
@@ -43,6 +43,7 @@ For fundamental QStash operations, see:
 - [Schedules](fundamentals/schedules.md)
 - [Queues and Flow Control](fundamentals/queues-and-flow-control.md)
 - [URL Groups](fundamentals/url-groups.md)
+- [Local Development](fundamentals/local-development.md) — automatic dev server via `devMode: true`
 
 For verifying incoming messages:
 

--- a/skills/upstash/upstash-workflow-js/how-to/local-dev.md
+++ b/skills/upstash/upstash-workflow-js/how-to/local-dev.md
@@ -6,7 +6,7 @@ This documentation explains how to run Upstash Workflow locally using the QStash
 
 Upstash Workflow uses Upstash QStash under the hood. During development you can:
 
-- Use the **automatic dev server** by setting `QSTASH_DEV=true` — the SDK downloads the QStash CLI binary, spawns the server, and verifies signatures with its dev keys. No tokens or signing keys required.
+- Use the **automatic dev server** by setting `QSTASH_DEV=true`. The SDK downloads the QStash CLI binary, spawns the server, and verifies signatures with its dev keys. No tokens or signing keys required.
 - Run a **local QStash development server** manually via the CLI and wire credentials yourself.
 - Optionally expose your local server using **ngrok** if you want to test with the production QStash.
 
@@ -14,7 +14,7 @@ Upstash Workflow uses Upstash QStash under the hood. During development you can:
 
 ## Automatic dev server (recommended)
 
-Set `QSTASH_DEV=true` in your environment and that's it — workflow's `serve()` endpoint and the `Client` both auto-detect it:
+Set `QSTASH_DEV=true` in your environment and that's it. Workflow's `serve()` endpoint and the `Client` both auto-detect it:
 
 ```
 QSTASH_DEV=true

--- a/skills/upstash/upstash-workflow-js/how-to/local-dev.md
+++ b/skills/upstash/upstash-workflow-js/how-to/local-dev.md
@@ -6,14 +6,63 @@ This documentation explains how to run Upstash Workflow locally using the QStash
 
 Upstash Workflow uses Upstash QStash under the hood. During development you can:
 
-- Run a **local QStash development server** to simulate workflow behavior entirely offline.
+- Use the **automatic dev server** by setting `QSTASH_DEV=true` — the SDK downloads the QStash CLI binary, spawns the server, and verifies signatures with its dev keys. No tokens or signing keys required.
+- Run a **local QStash development server** manually via the CLI and wire credentials yourself.
 - Optionally expose your local server using **ngrok** if you want to test with the production QStash.
 
-Both approaches require updating environment variables and ensuring your workflow trigger URLs correctly reference your local or tunnel address.
+---
+
+## Automatic dev server (recommended)
+
+Set `QSTASH_DEV=true` in your environment and that's it — workflow's `serve()` endpoint and the `Client` both auto-detect it:
+
+```
+QSTASH_DEV=true
+```
+
+```ts
+// app/api/workflow/route.ts
+import { serve } from "@upstash/workflow/nextjs";
+
+export const { POST } = serve(async (context) => {
+  await context.run("step-1", () => console.log("running locally"));
+});
+```
+
+```ts
+import { Client } from "@upstash/workflow";
+
+const client = new Client({ token: process.env.QSTASH_TOKEN ?? "" });
+
+await client.trigger({
+  url: "http://localhost:3000/api/workflow",
+});
+```
+
+When `QSTASH_DEV=true`:
+
+- The underlying `@upstash/qstash` client downloads the QStash CLI binary on first use, spawns the dev server on port `8080` (override via `QSTASH_DEV_PORT`), and reuses an already-running server on that port instead of spawning a duplicate.
+- `serve()` builds a dev-mode `Receiver` internally, so signature verification works against the dev server's deterministic signing keys with no real credentials.
+- It's a no-op in production (`NODE_ENV=production`), during `next build`, and in browser/edge runtimes.
+
+**Next.js edge routes:** the edge runtime cannot spawn child processes. If your workflow route runs on the Edge Runtime, call `registerQStashDev()` from `instrumentation.ts` so the binary starts at Next.js boot:
+
+```ts
+// instrumentation.ts
+import { registerQStashDev } from "@upstash/qstash/nextjs";
+
+export function register() {
+  registerQStashDev();
+}
+```
+
+See the [QStash Local Development skill](../../upstash-qstash-js/fundamentals/local-development.md) for the full reference, including pitfalls and CLI options.
 
 ---
 
 ## 1. Start the QStash Local Development Server
+
+If you'd rather manage the dev server yourself instead of using the automatic flow above, run the CLI manually.
 
 Use the QStash CLI:
 

--- a/skills/upstash/upstash-workflow-js/overview.md
+++ b/skills/upstash/upstash-workflow-js/overview.md
@@ -45,7 +45,7 @@ These files contain the full documentation. Use them for details, patterns, and 
   - **features/wait-for-event** – Notify and wait-for-event patterns.
   - **features/webhooks** – Webhook creation and consumption.
 - how to:
-  - **how-to/local-dev** – Local QStash dev server and tunneling.
+  - **how-to/local-dev** – Local QStash dev server (auto via `QSTASH_DEV=true`) and tunneling.
   - **how-to/realtime** – Realtime and human‑in‑the‑loop workflows.
   - **how-to/migrations** – Migrating workflows safely.
   - **how-to/middleware** – Adding middleware to workflows.


### PR DESCRIPTION
## Summary
- Adds `fundamentals/local-development.md` to the qstash-js skill covering `devMode: true`, `QSTASH_DEV` env, dev signature verification, and `registerQStashDev()` for Next.js edge.
- Regenerates `skills/upstash/`.

Companion to qstash-js `DX-2404-auto-dev-server` and docs upstash/docs#DX-2595.