### PR TITLE
fix(redis-js): correct search query skill and add $must/$should pitfall

### DIFF
--- a/skills/upstash-redis-js/SKILL.md
+++ b/skills/upstash-redis-js/SKILL.md
@@ -43,7 +43,7 @@ UPSTASH_REDIS_REST_TOKEN=your-token-here
 
 ## Skill Files Overview
 
-### Data Structures (skills/data-structures/)
+### Data Structures (data-structures/)
 
 Redis data types with auto-serialization examples:
 
@@ -55,7 +55,7 @@ Redis data types with auto-serialization examples:
 - **json.md** - JSON.SET, JSON.GET, JSONPath queries for nested objects
 - **streams.md** - XADD, XREAD, XGROUP, consumer groups
 
-### Advanced Features (skills/advanced-features/)
+### Advanced Features (advanced-features/)
 
 Complex operations and optimizations:
 
@@ -63,7 +63,7 @@ Complex operations and optimizations:
 - **pipeline-and-transactions.md** - Manual pipelines, MULTI/EXEC, WATCH for atomic operations
 - **scripting.md** - Lua scripts, EVAL, EVALSHA for server-side logic
 
-### Patterns (skills/patterns/)
+### Patterns (patterns/)
 
 Common use cases and architectural patterns:
 
@@ -73,7 +73,7 @@ Common use cases and architectural patterns:
 - **distributed-locks.md** - Lock implementations, deadlock prevention
 - **leaderboard.md** - Sorted set leaderboards, real-time rankings
 
-### Performance (skills/performance/)
+### Performance (performance/)
 
 Optimization techniques and best practices:
 
@@ -84,7 +84,7 @@ Optimization techniques and best practices:
 - **error-handling.md** - Error types, retry strategies, timeout handling, debugging tips
 - **redis-replicas.md** - Global database setup, read replicas, read-your-writes consistency
 
-### Search (skills/search/)
+### Search (search/)
 
 Full-text search, filtering, and aggregation extension for Redis:
 
@@ -95,7 +95,7 @@ Full-text search, filtering, and aggregation extension for Redis:
 - **commands/aliases.md** - Index aliases for zero-downtime reindexing
 - **adapters.md** - Using search with node-redis and ioredis via @upstash/search-redis and @upstash/search-ioredis
 
-### Migrations (skills/migrations/)
+### Migrations (migrations/)
 
 Migration guides from other libraries:
 

--- a/skills/upstash-redis-js/SKILL.md
+++ b/skills/upstash-redis-js/SKILL.md
@@ -60,7 +60,7 @@ Redis data types with auto-serialization examples:
 Complex operations and optimizations:
 
 - **auto-pipeline.md** - Automatic request batching, performance optimization
-- **pipeline-and-transactions.md** - Manual pipelines, MULTI/EXEC, WATCH for atomic operations
+- **pipeline-and-transactions.md** - Manual pipelines, MULTI/EXEC for atomic operations
 - **scripting.md** - Lua scripts, EVAL, EVALSHA for server-side logic
 
 ### Patterns (patterns/)

--- a/skills/upstash-redis-js/advanced-features/pipeline-and-transactions.md
+++ b/skills/upstash-redis-js/advanced-features/pipeline-and-transactions.md
@@ -12,8 +12,7 @@
 ## Limitations
 
 - Pipeline commands execute independently (no atomicity)
-- Transactions block other clients from modifying watched keys
-- WATCH only works for keys, not values
+- No WATCH / optimistic locking over the REST client — use a Lua script (`redis.eval`) for atomic check-and-set
 
 ## Examples
 

--- a/skills/upstash-redis-js/data-structures/sets.md
+++ b/skills/upstash-redis-js/data-structures/sets.md
@@ -63,6 +63,9 @@ await redis.sadd("set3", "c", "d", "e");
 const common = await redis.sinter("set1", "set2"); // ["b", "c"]
 const commonAll = await redis.sinter("set1", "set2", "set3"); // ["c"]
 
+// Count the intersection without returning members
+const commonCount = await redis.sintercard(["set1", "set2"]); // 2
+
 // Store intersection result in new set
 await redis.sinterstore("result", "set1", "set2");
 

--- a/skills/upstash-redis-js/performance/data-serialization.md
+++ b/skills/upstash-redis-js/performance/data-serialization.md
@@ -16,6 +16,7 @@ Automatic serialization preserves JavaScript types across Redis operations. Numb
 - undefined, functions, symbols cannot be serialized
 - Date objects serialize as ISO strings
 - Class instances lose their prototype
+- Map and Set serialize to `{}` (their contents are lost) — convert to a plain object/array first
 - Binary data requires special handling
 
 ## Examples

--- a/skills/upstash-redis-js/performance/error-handling.md
+++ b/skills/upstash-redis-js/performance/error-handling.md
@@ -80,3 +80,39 @@ try {
   }
 }
 ```
+
+### Error Types
+
+All SDK error classes are importable from `@upstash/redis`:
+
+| Error | `error.name` | When it's thrown |
+| --- | --- | --- |
+| `UpstashError` | `"UpstashError"` | A command failed server-side, or the REST response contained an `error` field. The base error type. |
+| `UpstashJSONParseError` | `"UpstashJSONParseError"` | The response body could not be parsed as JSON. Extends `UpstashError`. |
+| `UrlError` | `"UrlError"` | The client was constructed with an invalid URL (must start with `https`). Thrown synchronously at construction, before any request. |
+| `TimeoutError` | `"TimeoutError"` | A request was aborted by an `AbortSignal.timeout(...)`. This is the native DOM error, not an SDK class. |
+
+```typescript
+import { Redis, UpstashError } from "@upstash/redis";
+
+try {
+  await redis.get("key");
+} catch (error) {
+  if (error instanceof UpstashError) {
+    // command failed or bad request to Upstash
+    console.error("Upstash command failed:", error.message);
+  } else if (error.name === "TimeoutError") {
+    console.error("Request timed out");
+  } else {
+    throw error;
+  }
+}
+```
+
+Because `UpstashJSONParseError extends UpstashError`, a single `instanceof UpstashError` check catches both. `UrlError` is thrown when you construct the client, so it surfaces at startup rather than inside request `try/catch` blocks.
+
+### Debugging
+
+- **Read the message — it includes the failed command.** `UpstashError` messages are formatted like `<server error>, command was: ["GET","key"]`, so logging `error.message` shows exactly what was sent.
+- **`UrlError` at startup** almost always means a missing or typo'd `UPSTASH_REDIS_REST_URL` (it must start with `https://`). Verify env vars before suspecting the network.
+- **Retryable vs. fatal.** Network and `TimeoutError` failures are transient and already covered by the built-in `retry`. An `UpstashError` from a bad command (wrong argument types, `WRONGTYPE`, unknown command) is deterministic — retrying won't help, so fix the call instead of raising the retry count.

--- a/skills/upstash-redis-js/search/commands/querying.md
+++ b/skills/upstash-redis-js/search/commands/querying.md
@@ -104,9 +104,9 @@ const cheapest = await index.query({
 const results = await index.query({
   filter: { name: { $eq: "laptop" } },
   select: { name: true },
-  scoreFunc: { field: "name", modifier: "LOG1P" },
+  scoreFunc: { field: "name", modifier: "log1p" },
 });
-// Available modifiers: LOG, LOG1P, LOG2P, LN, LN1P, LN2P, SQRT, SQUARE, RECIPROCAL, NONE
+// Available modifiers: log, log1p, log2p, ln, ln1p, ln2p, square, sqrt, reciprocal, none
 ```
 
 ### Highlighting
@@ -136,10 +136,10 @@ const highlighted = await index.query({
 { name: { $in: ["laptop", "tablet"] } }
 
 // Fuzzy matching (typo tolerance)
-{ name: { $fuzzy: { term: "lapto", distance: 1 } } }
+{ name: { $fuzzy: { value: "lapto", distance: 1 } } }
 
 // Phrase matching (adjacent words with tolerance)
-{ name: { $phrase: { text: "gaming laptop", slop: 1 } } }
+{ name: { $phrase: { value: "gaming laptop", slop: 1 } } }
 
 // Regex pattern
 { name: { $regex: "lap.*" } }
@@ -252,6 +252,43 @@ Combine filters using boolean operators:
   ]
 }
 ```
+
+### Common mistake: `$should` next to `$must` does NOT filter
+
+Adding `$must` silently turns sibling `$should` clauses into **score boosters only** —
+documents are *not* required to match them. Membership is decided entirely by `$must`,
+so the query "always finds something" even for nonsense terms (matches come back, just
+with a low score). This is the most common search bug.
+
+```typescript
+// ❌ WRONG: the term only boosts; every in-stock doc still matches via $must,
+// so a nonsensical searchTerm still returns results (with low scores).
+{
+  $must: { inStock: { $eq: true } },
+  $should: [
+    { name: { $smart: searchTerm }, $boost: 10 },
+    { description: { $smart: searchTerm }, $boost: 5 },
+  ],
+}
+
+// ✅ RIGHT: require a match in at least one field by nesting the OR ($should
+// alone acts as OR) inside $must. $boost still ranks name above description.
+{
+  $must: [
+    { inStock: { $eq: true } },
+    {
+      $should: [
+        { name: { $smart: searchTerm }, $boost: 10 },
+        { description: { $smart: searchTerm }, $boost: 5 },
+      ],
+    },
+  ],
+}
+```
+
+> There is no minimum-score / cutoff option on `query()`. Don't filter by the returned
+> `score` (scores are relative and shift with `$boost`, so a fixed threshold isn't
+> reliable) — instead make the term required as above so non-matches are excluded.
 
 ### Boosting
 

--- a/skills/upstash/upstash-redis-js/advanced-features/pipeline-and-transactions.md
+++ b/skills/upstash/upstash-redis-js/advanced-features/pipeline-and-transactions.md
@@ -12,8 +12,7 @@
 ## Limitations
 
 - Pipeline commands execute independently (no atomicity)
-- Transactions block other clients from modifying watched keys
-- WATCH only works for keys, not values
+- No WATCH / optimistic locking over the REST client — use a Lua script (`redis.eval`) for atomic check-and-set
 
 ## Examples
 

--- a/skills/upstash/upstash-redis-js/data-structures/sets.md
+++ b/skills/upstash/upstash-redis-js/data-structures/sets.md
@@ -63,6 +63,9 @@ await redis.sadd("set3", "c", "d", "e");
 const common = await redis.sinter("set1", "set2"); // ["b", "c"]
 const commonAll = await redis.sinter("set1", "set2", "set3"); // ["c"]
 
+// Count the intersection without returning members
+const commonCount = await redis.sintercard(["set1", "set2"]); // 2
+
 // Store intersection result in new set
 await redis.sinterstore("result", "set1", "set2");
 

--- a/skills/upstash/upstash-redis-js/overview.md
+++ b/skills/upstash/upstash-redis-js/overview.md
@@ -38,7 +38,7 @@ UPSTASH_REDIS_REST_TOKEN=your-token-here
 
 ## Skill Files Overview
 
-### Data Structures (skills/data-structures/)
+### Data Structures (data-structures/)
 
 Redis data types with auto-serialization examples:
 
@@ -50,7 +50,7 @@ Redis data types with auto-serialization examples:
 - **json.md** - JSON.SET, JSON.GET, JSONPath queries for nested objects
 - **streams.md** - XADD, XREAD, XGROUP, consumer groups
 
-### Advanced Features (skills/advanced-features/)
+### Advanced Features (advanced-features/)
 
 Complex operations and optimizations:
 
@@ -58,7 +58,7 @@ Complex operations and optimizations:
 - **pipeline-and-transactions.md** - Manual pipelines, MULTI/EXEC, WATCH for atomic operations
 - **scripting.md** - Lua scripts, EVAL, EVALSHA for server-side logic
 
-### Patterns (skills/patterns/)
+### Patterns (patterns/)
 
 Common use cases and architectural patterns:
 
@@ -68,7 +68,7 @@ Common use cases and architectural patterns:
 - **distributed-locks.md** - Lock implementations, deadlock prevention
 - **leaderboard.md** - Sorted set leaderboards, real-time rankings
 
-### Performance (skills/performance/)
+### Performance (performance/)
 
 Optimization techniques and best practices:
 
@@ -79,7 +79,7 @@ Optimization techniques and best practices:
 - **error-handling.md** - Error types, retry strategies, timeout handling, debugging tips
 - **redis-replicas.md** - Global database setup, read replicas, read-your-writes consistency
 
-### Search (skills/search/)
+### Search (search/)
 
 Full-text search, filtering, and aggregation extension for Redis:
 
@@ -90,7 +90,7 @@ Full-text search, filtering, and aggregation extension for Redis:
 - **commands/aliases.md** - Index aliases for zero-downtime reindexing
 - **adapters.md** - Using search with node-redis and ioredis via @upstash/search-redis and @upstash/search-ioredis
 
-### Migrations (skills/migrations/)
+### Migrations (migrations/)
 
 Migration guides from other libraries:
 

--- a/skills/upstash/upstash-redis-js/overview.md
+++ b/skills/upstash/upstash-redis-js/overview.md
@@ -55,7 +55,7 @@ Redis data types with auto-serialization examples:
 Complex operations and optimizations:
 
 - **auto-pipeline.md** - Automatic request batching, performance optimization
-- **pipeline-and-transactions.md** - Manual pipelines, MULTI/EXEC, WATCH for atomic operations
+- **pipeline-and-transactions.md** - Manual pipelines, MULTI/EXEC for atomic operations
 - **scripting.md** - Lua scripts, EVAL, EVALSHA for server-side logic
 
 ### Patterns (patterns/)

--- a/skills/upstash/upstash-redis-js/performance/data-serialization.md
+++ b/skills/upstash/upstash-redis-js/performance/data-serialization.md
@@ -16,6 +16,7 @@ Automatic serialization preserves JavaScript types across Redis operations. Numb
 - undefined, functions, symbols cannot be serialized
 - Date objects serialize as ISO strings
 - Class instances lose their prototype
+- Map and Set serialize to `{}` (their contents are lost) — convert to a plain object/array first
 - Binary data requires special handling
 
 ## Examples

--- a/skills/upstash/upstash-redis-js/performance/error-handling.md
+++ b/skills/upstash/upstash-redis-js/performance/error-handling.md
@@ -80,3 +80,39 @@ try {
   }
 }
 ```
+
+### Error Types
+
+All SDK error classes are importable from `@upstash/redis`:
+
+| Error | `error.name` | When it's thrown |
+| --- | --- | --- |
+| `UpstashError` | `"UpstashError"` | A command failed server-side, or the REST response contained an `error` field. The base error type. |
+| `UpstashJSONParseError` | `"UpstashJSONParseError"` | The response body could not be parsed as JSON. Extends `UpstashError`. |
+| `UrlError` | `"UrlError"` | The client was constructed with an invalid URL (must start with `https`). Thrown synchronously at construction, before any request. |
+| `TimeoutError` | `"TimeoutError"` | A request was aborted by an `AbortSignal.timeout(...)`. This is the native DOM error, not an SDK class. |
+
+```typescript
+import { Redis, UpstashError } from "@upstash/redis";
+
+try {
+  await redis.get("key");
+} catch (error) {
+  if (error instanceof UpstashError) {
+    // command failed or bad request to Upstash
+    console.error("Upstash command failed:", error.message);
+  } else if (error.name === "TimeoutError") {
+    console.error("Request timed out");
+  } else {
+    throw error;
+  }
+}
+```
+
+Because `UpstashJSONParseError extends UpstashError`, a single `instanceof UpstashError` check catches both. `UrlError` is thrown when you construct the client, so it surfaces at startup rather than inside request `try/catch` blocks.
+
+### Debugging
+
+- **Read the message — it includes the failed command.** `UpstashError` messages are formatted like `<server error>, command was: ["GET","key"]`, so logging `error.message` shows exactly what was sent.
+- **`UrlError` at startup** almost always means a missing or typo'd `UPSTASH_REDIS_REST_URL` (it must start with `https://`). Verify env vars before suspecting the network.
+- **Retryable vs. fatal.** Network and `TimeoutError` failures are transient and already covered by the built-in `retry`. An `UpstashError` from a bad command (wrong argument types, `WRONGTYPE`, unknown command) is deterministic — retrying won't help, so fix the call instead of raising the retry count.

--- a/skills/upstash/upstash-redis-js/search/commands/querying.md
+++ b/skills/upstash/upstash-redis-js/search/commands/querying.md
@@ -104,9 +104,9 @@ const cheapest = await index.query({
 const results = await index.query({
   filter: { name: { $eq: "laptop" } },
   select: { name: true },
-  scoreFunc: { field: "name", modifier: "LOG1P" },
+  scoreFunc: { field: "name", modifier: "log1p" },
 });
-// Available modifiers: LOG, LOG1P, LOG2P, LN, LN1P, LN2P, SQRT, SQUARE, RECIPROCAL, NONE
+// Available modifiers: log, log1p, log2p, ln, ln1p, ln2p, square, sqrt, reciprocal, none
 ```
 
 ### Highlighting
@@ -136,10 +136,10 @@ const highlighted = await index.query({
 { name: { $in: ["laptop", "tablet"] } }
 
 // Fuzzy matching (typo tolerance)
-{ name: { $fuzzy: { term: "lapto", distance: 1 } } }
+{ name: { $fuzzy: { value: "lapto", distance: 1 } } }
 
 // Phrase matching (adjacent words with tolerance)
-{ name: { $phrase: { text: "gaming laptop", slop: 1 } } }
+{ name: { $phrase: { value: "gaming laptop", slop: 1 } } }
 
 // Regex pattern
 { name: { $regex: "lap.*" } }
@@ -252,6 +252,43 @@ Combine filters using boolean operators:
   ]
 }
 ```
+
+### Common mistake: `$should` next to `$must` does NOT filter
+
+Adding `$must` silently turns sibling `$should` clauses into **score boosters only** —
+documents are *not* required to match them. Membership is decided entirely by `$must`,
+so the query "always finds something" even for nonsense terms (matches come back, just
+with a low score). This is the most common search bug.
+
+```typescript
+// ❌ WRONG: the term only boosts; every in-stock doc still matches via $must,
+// so a nonsensical searchTerm still returns results (with low scores).
+{
+  $must: { inStock: { $eq: true } },
+  $should: [
+    { name: { $smart: searchTerm }, $boost: 10 },
+    { description: { $smart: searchTerm }, $boost: 5 },
+  ],
+}
+
+// ✅ RIGHT: require a match in at least one field by nesting the OR ($should
+// alone acts as OR) inside $must. $boost still ranks name above description.
+{
+  $must: [
+    { inStock: { $eq: true } },
+    {
+      $should: [
+        { name: { $smart: searchTerm }, $boost: 10 },
+        { description: { $smart: searchTerm }, $boost: 5 },
+      ],
+    },
+  ],
+}
+```
+
+> There is no minimum-score / cutoff option on `query()`. Don't filter by the returned
+> `score` (scores are relative and shift with `$boost`, so a fixed threshold isn't
+> reliable) — instead make the term required as above so non-matches are excluded.
 
 ### Boosting
 


### PR DESCRIPTION
## Why

Started from a user's Redis Search question (nonsense search terms still returned results). The root cause was a documented-but-unflagged behavior the skill didn't warn about. While fixing it I stress-tested the skill by having weak models answer real tasks using **only** the skill — haiku across 20 navigation tasks, plus DeepSeek V4 / GLM 5.2 via opencode on the original question — which surfaced several more gaps.

## Changes

- Add a "Common mistake" to search querying: `$should` next to `$must` only boosts score, it does **not** filter, so queries always match something; the fix is to nest the OR (`$should` alone) inside `$must`.
- Note there is no min-score cutoff on `query()`.
- Fix the `$fuzzy`/`$phrase` examples (`value`, not `term`/`text`) and lowercase the `scoreFunc` modifiers to match the SDK types.
- Drop the wrong `skills/` path prefix in the SKILL.md section headers — every test agent hit the dead path and had to glob.
- Fill `error-handling.md` with an error-type table and a debugging section so it delivers what the index promised.
- Drop the "WATCH for atomic operations" claim (the REST client has no WATCH) and point to `redis.eval` (Lua) for atomic check-and-set.
- Document `redis.sintercard()` in `sets.md`.
- Note that Map/Set don't round-trip in `data-serialization.md`.

All verified against `packages/redis` source. `skills/upstash/` regenerated via `scripts/build.mjs`; `scripts/check.mjs` passes.