### PR TITLE
Fix typo in 'Operations'

### DIFF
--- a/skills/upstash-vector-js/features/namespaces.md
+++ b/skills/upstash-vector-js/features/namespaces.md
@@ -20,7 +20,7 @@ await ns.upsert({ id: "id-0", vector: [0.1, 0.2] });
 await ns.query({ vector: [0.1, 0.2], topK: 5 });
 ```
 
-## Operatoins
+## Operations
 
 ```ts
 await index.deleteNamespace("ns");

--- a/skills/upstash/upstash-vector-js/features/namespaces.md
+++ b/skills/upstash/upstash-vector-js/features/namespaces.md
@@ -20,7 +20,7 @@ await ns.upsert({ id: "id-0", vector: [0.1, 0.2] });
 await ns.query({ vector: [0.1, 0.2], topK: 5 });
 ```
 
-## Operatoins
+## Operations
 
 ```ts
 await index.deleteNamespace("ns");


### PR DESCRIPTION
This pull request makes a minor correction to the documentation in `skills/upstash-vector-js/features/namespaces.md` by fixing a typo in a section heading. The heading `## Operatoins` is corrected to `## Operations`.