### PR TITLE
feat: add Agent Plugins portable manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "upstash",
       "source": "./",
-      "description": "Agent skills for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box."
+      "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "upstash",
-  "description": "Agent skills for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box.",
+  "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search.",
   "version": "1.0.0",
   "author": {
     "name": "Upstash",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "upstash",
   "version": "1.0.0",
-  "description": "Agent skills for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box.",
+  "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search.",
   "author": {
     "name": "Upstash",
     "email": "support@upstash.com"
@@ -13,7 +13,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Upstash",
-    "shortDescription": "Skills for Upstash SDKs (Redis, Vector, QStash, Workflow, Search, Box)",
+    "shortDescription": "Skills for Upstash SDKs (Redis, QStash, Workflow, Box, Ratelimit, Vector, Search)",
     "category": "Productivity",
     "developerName": "Upstash",
     "websiteURL": "https://upstash.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "upstash",
       "source": "./",
-      "description": "Agent skills for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box."
+      "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search."
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "upstash",
-  "displayName": "Upstash",
-  "description": "Agent skills for all Upstash SDKs — QStash, Vector, Workflow, Ratelimit, Search, Redis, and Box.",
+  "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search.",
   "version": "1.0.0",
   "author": {
     "name": "Upstash",
@@ -10,6 +9,5 @@
   "homepage": "https://upstash.com",
   "repository": "https://github.com/upstash/skills",
   "license": "MIT",
-  "keywords": ["upstash", "redis", "qstash", "vector", "workflow", "serverless", "sandbox"],
-  "skills": "./skills/"
+  "keywords": ["upstash", "redis", "qstash", "vector", "workflow", "serverless", "sandbox"]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "upstash",
+  "version": "1.0.0",
+  "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search.",
+  "author": {
+    "name": "Upstash",
+    "email": "support@upstash.com",
+    "url": "https://upstash.com"
+  },
+  "homepage": "https://upstash.com",
+  "repository": "https://github.com/upstash/skills",
+  "license": "MIT",
+  "keywords": ["upstash", "redis", "qstash", "vector", "workflow", "serverless", "sandbox"]
+}


### PR DESCRIPTION
dd a root plugin.json conforming to the Agent Plugins 1.0.0 [spec](https://agent-plugins.org). Skills are auto-discovered from skills/, so no other changes are needed; there is no MCP server, so no mcp.json.