### PR TITLE
docs(box skills): clarify sandbox trust boundaries in git, skills, MCP

### DIFF
--- a/skills/upstash-box-js/SKILL.md
+++ b/skills/upstash-box-js/SKILL.md
@@ -257,6 +257,10 @@ await box.cd("/workspace/home/other") // absolute path
 
 ## Git
 
+Clones land inside the box's isolated container, never on the caller's machine. Cloned
+code is data until something runs it — treat an untrusted repo as untrusted input, and
+pair it with a restrictive `networkPolicy` (see below) before running its build or tests.
+
 ```ts
 await box.git.clone({ repo: "github.com/org/repo", branch: "main" })
 await box.git.clone({ repo: "github.com/org/repo", depth: 1 }) // shallow clone
@@ -436,6 +440,10 @@ await box.deletePublicURL(3000)
 
 Install agent skills from the Context7 registry. Format: `owner/repo/skill-name`.
 
+An installed skill becomes instructions for the box's agent, so pin skills to owners you
+trust the same way you would a dependency. Skills resolve from the registry at box
+creation, not from arbitrary URLs, and they only ever run inside the box's container.
+
 ```ts
 const box = await Box.create({ skills: ["upstash/qstash-js/qstash-js"] })
 
@@ -473,14 +481,16 @@ await box.updateNetworkPolicy({ mode: "deny-all" })
 
 ## MCP Servers
 
-Attach MCP servers to the box agent.
+Attach MCP servers to the box agent. An attached server supplies tools the agent can call,
+so use servers you control or trust — and keep `networkPolicy` restrictive when the agent
+also handles untrusted input.
 
 ```ts
 const box = await Box.create({
   agent: { harness: Agent.ClaudeCode, model: ClaudeCode.Sonnet_4_5 },
   mcpServers: [
     { name: "fs", package: "@modelcontextprotocol/server-filesystem", args: [] },
-    { name: "custom", url: "https://mcp.example.com/sse", headers: { Authorization: "..." } },
+    { name: "custom", url: "<your-mcp-server-url>", headers: { Authorization: "..." } },
   ],
 })
 ```

--- a/skills/upstash-box-py/SKILL.md
+++ b/skills/upstash-box-py/SKILL.md
@@ -265,6 +265,10 @@ box.cd("/workspace/home/other")    # absolute path
 
 ## Git
 
+Clones land inside the box's isolated container, never on the caller's machine. Cloned
+code is data until something runs it — treat an untrusted repo as untrusted input, and
+pair it with a restrictive `network_policy` (see below) before running its build or tests.
+
 ```python
 box.git.clone(repo="github.com/org/repo", branch="main")
 box.git.clone(repo="github.com/org/repo", depth=1)  # shallow clone
@@ -449,6 +453,10 @@ box.delete_public_url(3000)
 
 Install agent skills from the Context7 registry. Format: `owner/repo/skill-name`.
 
+An installed skill becomes instructions for the box's agent, so pin skills to owners you
+trust the same way you would a dependency. Skills resolve from the registry at box
+creation, not from arbitrary URLs, and they only ever run inside the box's container.
+
 ```python
 box = Box.create(skills=["upstash/qstash-js/qstash-js"])
 
@@ -489,14 +497,16 @@ box.update_network_policy({"mode": "deny-all"})
 
 ## MCP Servers
 
-Attach MCP servers to the box agent.
+Attach MCP servers to the box agent. An attached server supplies tools the agent can call,
+so use servers you control or trust — and keep `network_policy` restrictive when the agent
+also handles untrusted input.
 
 ```python
 box = Box.create(
     agent={"harness": Agent.CLAUDE_CODE, "model": ClaudeCode.SONNET_4_5},
     mcp_servers=[
         {"name": "fs", "package": "@modelcontextprotocol/server-filesystem"},
-        {"name": "custom", "url": "https://mcp.example.com/sse", "headers": {"Authorization": "..."}},
+        {"name": "custom", "url": "<your-mcp-server-url>", "headers": {"Authorization": "..."}},
     ],
 )
 ```

--- a/skills/upstash/upstash-box-js/overview.md
+++ b/skills/upstash/upstash-box-js/overview.md
@@ -252,6 +252,10 @@ await box.cd("/workspace/home/other") // absolute path
 
 ## Git
 
+Clones land inside the box's isolated container, never on the caller's machine. Cloned
+code is data until something runs it — treat an untrusted repo as untrusted input, and
+pair it with a restrictive `networkPolicy` (see below) before running its build or tests.
+
 ```ts
 await box.git.clone({ repo: "github.com/org/repo", branch: "main" })
 await box.git.clone({ repo: "github.com/org/repo", depth: 1 }) // shallow clone
@@ -431,6 +435,10 @@ await box.deletePublicURL(3000)
 
 Install agent skills from the Context7 registry. Format: `owner/repo/skill-name`.
 
+An installed skill becomes instructions for the box's agent, so pin skills to owners you
+trust the same way you would a dependency. Skills resolve from the registry at box
+creation, not from arbitrary URLs, and they only ever run inside the box's container.
+
 ```ts
 const box = await Box.create({ skills: ["upstash/qstash-js/qstash-js"] })
 
@@ -468,14 +476,16 @@ await box.updateNetworkPolicy({ mode: "deny-all" })
 
 ## MCP Servers
 
-Attach MCP servers to the box agent.
+Attach MCP servers to the box agent. An attached server supplies tools the agent can call,
+so use servers you control or trust — and keep `networkPolicy` restrictive when the agent
+also handles untrusted input.
 
 ```ts
 const box = await Box.create({
   agent: { harness: Agent.ClaudeCode, model: ClaudeCode.Sonnet_4_5 },
   mcpServers: [
     { name: "fs", package: "@modelcontextprotocol/server-filesystem", args: [] },
-    { name: "custom", url: "https://mcp.example.com/sse", headers: { Authorization: "..." } },
+    { name: "custom", url: "<your-mcp-server-url>", headers: { Authorization: "..." } },
   ],
 })
 ```

--- a/skills/upstash/upstash-box-py/overview.md
+++ b/skills/upstash/upstash-box-py/overview.md
@@ -260,6 +260,10 @@ box.cd("/workspace/home/other")    # absolute path
 
 ## Git
 
+Clones land inside the box's isolated container, never on the caller's machine. Cloned
+code is data until something runs it — treat an untrusted repo as untrusted input, and
+pair it with a restrictive `network_policy` (see below) before running its build or tests.
+
 ```python
 box.git.clone(repo="github.com/org/repo", branch="main")
 box.git.clone(repo="github.com/org/repo", depth=1)  # shallow clone
@@ -444,6 +448,10 @@ box.delete_public_url(3000)
 
 Install agent skills from the Context7 registry. Format: `owner/repo/skill-name`.
 
+An installed skill becomes instructions for the box's agent, so pin skills to owners you
+trust the same way you would a dependency. Skills resolve from the registry at box
+creation, not from arbitrary URLs, and they only ever run inside the box's container.
+
 ```python
 box = Box.create(skills=["upstash/qstash-js/qstash-js"])
 
@@ -484,14 +492,16 @@ box.update_network_policy({"mode": "deny-all"})
 
 ## MCP Servers
 
-Attach MCP servers to the box agent.
+Attach MCP servers to the box agent. An attached server supplies tools the agent can call,
+so use servers you control or trust — and keep `network_policy` restrictive when the agent
+also handles untrusted input.
 
 ```python
 box = Box.create(
     agent={"harness": Agent.CLAUDE_CODE, "model": ClaudeCode.SONNET_4_5},
     mcp_servers=[
         {"name": "fs", "package": "@modelcontextprotocol/server-filesystem"},
-        {"name": "custom", "url": "https://mcp.example.com/sse", "headers": {"Authorization": "..."}},
+        {"name": "custom", "url": "<your-mcp-server-url>", "headers": {"Authorization": "..."}},
     ],
 )
 ```


### PR DESCRIPTION
Addresses Snyk agent-scan findings surfaced on skills.sh for upstash-box-js, upstash-box-py, and the generated upstash bundle (which inherits both).

- Replace the mcp.example.com/sse placeholder with <your-mcp-server-url>. box-py's W012 (unverifiable external dependency) quoted that literal URL as its evidence, reading a docs placeholder as a real runtime dependency.
- Add trust framing directly above the Git, Skills, and MCP Servers code blocks that trigger W011/W012. The mitigations (network_policy, container isolation) were already documented, but ~40 lines away under Network Policy.

No capabilities or examples removed — only added context. The remaining W011 findings on qstash-js, workflow-js, and redis-start are inherent to what those SDKs do and are not addressed here.

Ref: DX-2926