### PR TITLE
Add an upstash-box-cli skill and correct the box git docs

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "upstash",
       "source": "./",
-      "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search."
+      "description": "Agent skills for Upstash SDKs and CLIs — Redis, QStash, Workflow, Box (SDKs and the box CLI), Ratelimit, Vector, and Search."
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "upstash",
-  "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search.",
+  "description": "Agent skills for Upstash SDKs and CLIs — Redis, QStash, Workflow, Box (SDKs and the box CLI), Ratelimit, Vector, and Search.",
   "version": "1.0.0",
   "author": {
     "name": "Upstash",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Upstash Agent Skills
 
-A collection of skills for AI coding agents working with Upstash SDKs. Skills are packaged instructions and resources that extend agent capabilities.
+A collection of skills for AI coding agents working with Upstash SDKs and CLIs. Skills are packaged instructions and resources that extend agent capabilities.
 
 This repo works as an [Agent Skills](https://agentskills.io/) repo, a [Claude Code plugin](https://code.claude.com/docs/en/plugins), a [Cursor plugin](https://cursor.com/docs/plugins), an [OpenAI Codex plugin](https://developers.openai.com/codex/plugins/build), and a [DeepSeek Harness bundle](https://github.com/deepseek-ai/deepseek-harness). It also installs into [OpenCode](#opencode), [Zed](#zed), and any other Agent Skills-compatible client with `npx skills add`.
 
@@ -8,7 +8,8 @@ This repo works as an [Agent Skills](https://agentskills.io/) repo, a [Claude Co
 
 | Skill | Description |
 |-------|-------------|
-| [upstash](skills/upstash/) | Combined skill covering all Upstash SDKs. |
+| [upstash](skills/upstash/) | Combined skill covering all Upstash SDKs and CLIs. |
+| [upstash-box-cli](skills/upstash-box-cli/) | Drive a sandboxed cloud container from the terminal with the `box` CLI. |
 | [upstash-box-js](skills/upstash-box-js/) | Sandboxed cloud containers with AI agents, shell, filesystem, and git. |
 | [upstash-box-py](skills/upstash-box-py/) | The same sandboxed cloud containers, from the Python SDK. |
 | [upstash-cli](skills/upstash-cli/) | Drive the Upstash Developer API from the terminal with the `upstash` CLI. |

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "upstash",
   "version": "1.0.0",
-  "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search.",
+  "description": "Agent skills for Upstash SDKs and CLIs — Redis, QStash, Workflow, Box (SDKs and the box CLI), Ratelimit, Vector, and Search.",
   "author": {
     "name": "Upstash",
     "email": "support@upstash.com",

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -54,6 +54,45 @@ box exec -- '( npm run dev > dev.log 2>&1 & )'
 box public-url 3000                               # prints the public URL
 ```
 
+## Building something and handing back a link
+
+"Make me a snake game, use Upstash Box" is a request to build it in a box, run it
+there, and reply with a URL the user can open. Do the whole thing; do not stop at
+writing the file.
+
+```bash
+box create --no-repl --runtime node          # writes .box, so later commands need no --box
+
+box files write index.html - <<'HTML'
+<!doctype html><meta charset="utf-8"><title>Snake</title>
+<canvas id="c" width="400" height="400"></canvas>
+<script>/* the game */</script>
+HTML
+
+box files write server.js - <<'JS'
+const http = require("http"), fs = require("fs");
+http.createServer((_, res) => {
+  res.writeHead(200, { "Content-Type": "text/html" });
+  res.end(fs.readFileSync("index.html"));
+}).listen(3000);
+JS
+
+box exec -- '( node server.js > server.log 2>&1 & )'          # detached, or it dies
+box exec -- 'sleep 1; curl -sf localhost:3000 >/dev/null && echo up'
+box public-url 3000                                           # the link to reply with
+```
+
+Node's own `http` module rather than a package: no install, no network fetch, and it
+works on a bare `node` runtime.
+
+Check the port answers before publishing it. A public URL for a port nothing is
+listening on returns 502, which reads as a broken game rather than as a race with a
+server that had not finished starting.
+
+Reply with the URL itself, not just "it is running". Say that the box keeps costing
+money until `box delete --yes`, and that the URL is public to anyone who has it —
+`box public-url 3000 --basic-auth` puts credentials in front of it.
+
 ## Files
 
 Paths are relative to `/workspace/home`.
@@ -115,7 +154,9 @@ commands above; `box run` is for delegating a whole task to the box's own agent.
 ## Output
 
 Data goes to stdout, diagnostics to stderr, so piping is safe. `--json` prints the
-result as JSON with no wrapper and works on any command:
+result as JSON with no wrapper, on every command that returns data. The ones that
+open a REPL or print a shell script (`connect`, `from-snapshot`, `init-demo`,
+`completion`) reject it rather than answering an automation caller with a prompt:
 
 ```bash
 box files list --json | jq -r '.[].name'

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -39,6 +39,10 @@ box exec -C repo -- npm test
 box exec --json -- node -e 'console.log(1)'   # {stdout, stderr, exit_code}
 ```
 
+One argument is a shell expression, sent as written, so pipes and redirection work.
+Several arguments are argv and are quoted individually, so an argument containing
+spaces stays one argument.
+
 The remote command's exit code is passed through, so `box exec -- npm test && ...`
 chains normally. Exit code **125** means the CLI itself failed (bad box, bad flags),
 never a status the remote command returned.

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -6,6 +6,22 @@ description: Drive an Upstash Box (a remote sandboxed workspace) from the termin
 `box` operates on a **remote container**, not this machine. Your own file and shell
 tools act locally; anything that must happen inside the box goes through `box`.
 
+## Install
+
+```bash
+npm i -g @upstash/box-cli
+```
+
+## Authentication
+
+Every command needs an API key, or it fails with "API token required". Set it once,
+or pass `--token` on any single command. Create one at
+https://console.upstash.com/box.
+
+```bash
+export UPSTASH_BOX_API_KEY=box_...
+```
+
 ## Selecting a box
 
 Resolution order is `--box <id>`, then `$BOX_ID`, then the nearest `.box` file

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -51,7 +51,7 @@ A background server dies with the command that started it. Detach it:
 
 ```bash
 box exec -- '( npm run dev > dev.log 2>&1 & )'
-box expose 3000                               # prints the public URL
+box public-url 3000                               # prints the public URL
 ```
 
 ## Files

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upstash-box-cli
-description: Drive an Upstash Box (a remote sandboxed workspace) from the terminal with the `box` CLI. Use when asked to run commands, edit files, clone repos, run builds or tests, expose a preview URL, or do any work inside a box rather than on this machine.
+description: Drive an Upstash Box (a remote sandboxed workspace) from the terminal with the `box` CLI. Use when asked to run commands, edit files, clone repos, run builds or tests, publish a public URL, or do any work inside a box rather than on this machine.
 ---
 
 `box` operates on a **remote container**, not this machine. Your own file and shell

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: upstash-box-cli
+description: Drive an Upstash Box (a remote sandboxed workspace) from the terminal with the `box` CLI. Use when asked to run commands, edit files, clone repos, run builds or tests, expose a preview URL, or do any work inside a box rather than on this machine.
+---
+
+`box` operates on a **remote container**, not this machine. Your own file and shell
+tools act locally; anything that must happen inside the box goes through `box`.
+
+## Selecting a box
+
+Resolution order is `--box <id>`, then `$BOX_ID`, then the nearest `.box` file
+(searched upward). Create one and pin it to the working directory:
+
+```bash
+box create --no-repl --runtime node                    # prints the id, writes .box
+box create --no-repl --runtime node --clone-repo https://github.com/org/repo
+box status                                             # id, where it came from, state
+```
+
+`paused` is not an error; the next command resumes the box.
+
+Clean up when the work is done. Boxes cost money while they exist:
+
+```bash
+box pause                   # keeps the workspace, resumes on the next command
+box delete --yes            # irreversible; --yes is required without a terminal
+```
+
+Never run `box create` without `--no-repl`, or `box connect` / `box from-snapshot`:
+they open an interactive REPL and will hang.
+
+## Running commands
+
+Put the remote command after `--`, or its flags are parsed as `box`'s own.
+
+```bash
+box exec -- npm install
+box exec -C repo -- npm test
+box exec --json -- node -e 'console.log(1)'   # {stdout, stderr, exit_code}
+```
+
+The remote command's exit code is passed through, so `box exec -- npm test && ...`
+chains normally. Exit code **125** means the CLI itself failed (bad box, bad flags),
+never a status the remote command returned.
+
+A background server dies with the command that started it. Detach it:
+
+```bash
+box exec -- '( npm run dev > dev.log 2>&1 & )'
+box expose 3000                               # prints the public URL
+```
+
+## Files
+
+Paths are relative to `/workspace/home`.
+
+```bash
+box files list src
+box files read src/index.ts
+box files write src/app.ts -    < local.ts    # - reads stdin: use this for code
+box files write notes.txt "short text"
+box files stat src/index.ts
+box files mkdir -p a/b/c
+box files rename old.ts new.ts
+box files remove build -r                      # a directory needs -r
+box files upload ./local.zip /workspace/home/local.zip
+box files download repo
+```
+
+Write code with `-` and stdin. Passing source as an argument mangles it in the shell.
+
+To search, use the box's own tools: `box exec -- grep -rn TODO src`.
+
+## Git
+
+A clone lands in a directory named after the repo, and every git verb except `clone`
+needs that directory via `-C`. Without it git runs at the workspace root, which is not
+a repository.
+
+```bash
+box git clone https://github.com/org/repo
+box git clone https://github.com/org/repo -C my-app   # -C is the destination here
+box git status -C repo
+box git diff -C repo
+box git config -C repo --name "Bot" --email bot@example.com
+box git checkout -C repo feature/x             # creates the branch if missing
+box git exec -C repo -- add -A
+box git commit -C repo -m "message"
+box git push -C repo
+box git create-pr -C repo --title "Fix the thing" --base main
+```
+
+`box git exec` takes git's arguments without the leading `git`, and passes git's exit
+code through.
+
+Private repos and PRs need a token at creation: `box create --no-repl --git-token $GITHUB_TOKEN`.
+
+## Agent
+
+If the box was created with an agent, hand it a task:
+
+```bash
+box create --no-repl --agent-harness claude-code --agent-model anthropic/claude-sonnet-5
+box run "Fix the failing test in src/auth.test.ts"
+box run - < prompt.txt
+```
+
+Text goes to stdout, tool calls to stderr. Prefer doing the work yourself with the
+commands above; `box run` is for delegating a whole task to the box's own agent.
+
+## Output
+
+Data goes to stdout, diagnostics to stderr, so piping is safe. `--json` prints the
+result as JSON with no wrapper and works on any command:
+
+```bash
+box files list --json | jq -r '.[].name'
+box get "$(cat .box)" --json
+```

--- a/skills/upstash-box-js/SKILL.md
+++ b/skills/upstash-box-js/SKILL.md
@@ -328,10 +328,15 @@ Clones land inside the box's isolated container, never on the caller's machine. 
 code is data until something runs it — treat an untrusted repo as untrusted input, and
 pair it with a restrictive `networkPolicy` (see below) before running its build or tests.
 
+Every git call except `clone` runs in the box's current directory, so `cd` into the
+clone first. At the workspace root there is no repository, and `status` comes back
+empty, which reads as a clean tree.
+
 ```ts
 await box.git.clone({ repo: "github.com/org/repo", branch: "main" })
 await box.git.clone({ repo: "github.com/org/repo", depth: 1 }) // shallow clone
-await box.cd("repo") // cd into cloned repo
+await box.git.clone({ repo: "github.com/org/repo", folder: "my-app" }) // destination
+await box.cd("repo") // the clone lands in a directory named after the repo
 
 const status = await box.git.status()
 const diff = await box.git.diff()
@@ -350,8 +355,8 @@ const pr = await box.git.createPR({ title: "Fix bug", body: "...", base: "main" 
 const cfg = await box.git.updateConfig({ userName: "Bot", userEmail: "bot@example.com" })
 // cfg: { git_user_name, git_user_email }
 
-// Arbitrary git commands
-const { output } = await box.git.exec({ args: ["log", "--oneline", "-5"] })
+// Arbitrary git commands. Check exit_code: 128 means the cwd is not a repository.
+const { output, exit_code } = await box.git.exec({ args: ["log", "--oneline", "-5"] })
 ```
 
 ## Schedules

--- a/skills/upstash-box-py/SKILL.md
+++ b/skills/upstash-box-py/SKILL.md
@@ -346,10 +346,15 @@ Clones land inside the box's isolated container, never on the caller's machine. 
 code is data until something runs it — treat an untrusted repo as untrusted input, and
 pair it with a restrictive `network_policy` (see below) before running its build or tests.
 
+Every git call except `clone` runs in the box's current directory, so `cd` into the
+clone first. At the workspace root there is no repository, and `status` comes back
+empty, which reads as a clean tree.
+
 ```python
 box.git.clone(repo="github.com/org/repo", branch="main")
 box.git.clone(repo="github.com/org/repo", depth=1)  # shallow clone
-box.cd("repo")  # cd into cloned repo
+box.git.clone(repo="github.com/org/repo", folder="my-app")  # destination
+box.cd("repo")  # the clone lands in a directory named after the repo
 
 status = box.git.status()
 diff = box.git.diff()

--- a/skills/upstash/SKILL.md
+++ b/skills/upstash/SKILL.md
@@ -9,7 +9,7 @@ This skill combines documentation for all Upstash SDKs. Pick the relevant sub-sk
 
 ## [upstash-box-cli](upstash-box-cli/overview.md)
 
-Drive an Upstash Box (a remote sandboxed workspace) from the terminal with the `box` CLI. Use when asked to run commands, edit files, clone repos, run builds or tests, expose a preview URL, or do any work inside a box rather than on this machine.
+Drive an Upstash Box (a remote sandboxed workspace) from the terminal with the `box` CLI. Use when asked to run commands, edit files, clone repos, run builds or tests, publish a public URL, or do any work inside a box rather than on this machine.
 
 ## [upstash-box-js](upstash-box-js/overview.md)
 

--- a/skills/upstash/SKILL.md
+++ b/skills/upstash/SKILL.md
@@ -7,6 +7,10 @@ description: Work with any Upstash SDK or tool including Redis, Box (TypeScript/
 
 This skill combines documentation for all Upstash SDKs. Pick the relevant sub-skill below.
 
+## [upstash-box-cli](upstash-box-cli/overview.md)
+
+Drive an Upstash Box (a remote sandboxed workspace) from the terminal with the `box` CLI. Use when asked to run commands, edit files, clone repos, run builds or tests, expose a preview URL, or do any work inside a box rather than on this machine.
+
 ## [upstash-box-js](upstash-box-js/overview.md)
 
 Work with the @upstash/box TypeScript/JavaScript SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, and a headless browser. Use when building with Upstash Box, creating sandboxed environments, running AI agents in containers, browser automation from a box, or orchestrating parallel boxes.

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -49,6 +49,45 @@ box exec -- '( npm run dev > dev.log 2>&1 & )'
 box public-url 3000                               # prints the public URL
 ```
 
+## Building something and handing back a link
+
+"Make me a snake game, use Upstash Box" is a request to build it in a box, run it
+there, and reply with a URL the user can open. Do the whole thing; do not stop at
+writing the file.
+
+```bash
+box create --no-repl --runtime node          # writes .box, so later commands need no --box
+
+box files write index.html - <<'HTML'
+<!doctype html><meta charset="utf-8"><title>Snake</title>
+<canvas id="c" width="400" height="400"></canvas>
+<script>/* the game */</script>
+HTML
+
+box files write server.js - <<'JS'
+const http = require("http"), fs = require("fs");
+http.createServer((_, res) => {
+  res.writeHead(200, { "Content-Type": "text/html" });
+  res.end(fs.readFileSync("index.html"));
+}).listen(3000);
+JS
+
+box exec -- '( node server.js > server.log 2>&1 & )'          # detached, or it dies
+box exec -- 'sleep 1; curl -sf localhost:3000 >/dev/null && echo up'
+box public-url 3000                                           # the link to reply with
+```
+
+Node's own `http` module rather than a package: no install, no network fetch, and it
+works on a bare `node` runtime.
+
+Check the port answers before publishing it. A public URL for a port nothing is
+listening on returns 502, which reads as a broken game rather than as a race with a
+server that had not finished starting.
+
+Reply with the URL itself, not just "it is running". Say that the box keeps costing
+money until `box delete --yes`, and that the URL is public to anyone who has it —
+`box public-url 3000 --basic-auth` puts credentials in front of it.
+
 ## Files
 
 Paths are relative to `/workspace/home`.
@@ -110,7 +149,9 @@ commands above; `box run` is for delegating a whole task to the box's own agent.
 ## Output
 
 Data goes to stdout, diagnostics to stderr, so piping is safe. `--json` prints the
-result as JSON with no wrapper and works on any command:
+result as JSON with no wrapper, on every command that returns data. The ones that
+open a REPL or print a shell script (`connect`, `from-snapshot`, `init-demo`,
+`completion`) reject it rather than answering an automation caller with a prompt:
 
 ```bash
 box files list --json | jq -r '.[].name'

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -34,6 +34,10 @@ box exec -C repo -- npm test
 box exec --json -- node -e 'console.log(1)'   # {stdout, stderr, exit_code}
 ```
 
+One argument is a shell expression, sent as written, so pipes and redirection work.
+Several arguments are argv and are quoted individually, so an argument containing
+spaces stays one argument.
+
 The remote command's exit code is passed through, so `box exec -- npm test && ...`
 chains normally. Exit code **125** means the CLI itself failed (bad box, bad flags),
 never a status the remote command returned.

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -46,7 +46,7 @@ A background server dies with the command that started it. Detach it:
 
 ```bash
 box exec -- '( npm run dev > dev.log 2>&1 & )'
-box expose 3000                               # prints the public URL
+box public-url 3000                               # prints the public URL
 ```
 
 ## Files

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -1,0 +1,114 @@
+`box` operates on a **remote container**, not this machine. Your own file and shell
+tools act locally; anything that must happen inside the box goes through `box`.
+
+## Selecting a box
+
+Resolution order is `--box <id>`, then `$BOX_ID`, then the nearest `.box` file
+(searched upward). Create one and pin it to the working directory:
+
+```bash
+box create --no-repl --runtime node                    # prints the id, writes .box
+box create --no-repl --runtime node --clone-repo https://github.com/org/repo
+box status                                             # id, where it came from, state
+```
+
+`paused` is not an error; the next command resumes the box.
+
+Clean up when the work is done. Boxes cost money while they exist:
+
+```bash
+box pause                   # keeps the workspace, resumes on the next command
+box delete --yes            # irreversible; --yes is required without a terminal
+```
+
+Never run `box create` without `--no-repl`, or `box connect` / `box from-snapshot`:
+they open an interactive REPL and will hang.
+
+## Running commands
+
+Put the remote command after `--`, or its flags are parsed as `box`'s own.
+
+```bash
+box exec -- npm install
+box exec -C repo -- npm test
+box exec --json -- node -e 'console.log(1)'   # {stdout, stderr, exit_code}
+```
+
+The remote command's exit code is passed through, so `box exec -- npm test && ...`
+chains normally. Exit code **125** means the CLI itself failed (bad box, bad flags),
+never a status the remote command returned.
+
+A background server dies with the command that started it. Detach it:
+
+```bash
+box exec -- '( npm run dev > dev.log 2>&1 & )'
+box expose 3000                               # prints the public URL
+```
+
+## Files
+
+Paths are relative to `/workspace/home`.
+
+```bash
+box files list src
+box files read src/index.ts
+box files write src/app.ts -    < local.ts    # - reads stdin: use this for code
+box files write notes.txt "short text"
+box files stat src/index.ts
+box files mkdir -p a/b/c
+box files rename old.ts new.ts
+box files remove build -r                      # a directory needs -r
+box files upload ./local.zip /workspace/home/local.zip
+box files download repo
+```
+
+Write code with `-` and stdin. Passing source as an argument mangles it in the shell.
+
+To search, use the box's own tools: `box exec -- grep -rn TODO src`.
+
+## Git
+
+A clone lands in a directory named after the repo, and every git verb except `clone`
+needs that directory via `-C`. Without it git runs at the workspace root, which is not
+a repository.
+
+```bash
+box git clone https://github.com/org/repo
+box git clone https://github.com/org/repo -C my-app   # -C is the destination here
+box git status -C repo
+box git diff -C repo
+box git config -C repo --name "Bot" --email bot@example.com
+box git checkout -C repo feature/x             # creates the branch if missing
+box git exec -C repo -- add -A
+box git commit -C repo -m "message"
+box git push -C repo
+box git create-pr -C repo --title "Fix the thing" --base main
+```
+
+`box git exec` takes git's arguments without the leading `git`, and passes git's exit
+code through.
+
+Private repos and PRs need a token at creation: `box create --no-repl --git-token $GITHUB_TOKEN`.
+
+## Agent
+
+If the box was created with an agent, hand it a task:
+
+```bash
+box create --no-repl --agent-harness claude-code --agent-model anthropic/claude-sonnet-5
+box run "Fix the failing test in src/auth.test.ts"
+box run - < prompt.txt
+```
+
+Text goes to stdout, tool calls to stderr. Prefer doing the work yourself with the
+commands above; `box run` is for delegating a whole task to the box's own agent.
+
+## Output
+
+Data goes to stdout, diagnostics to stderr, so piping is safe. `--json` prints the
+result as JSON with no wrapper and works on any command:
+
+```bash
+box files list --json | jq -r '.[].name'
+box get "$(cat .box)" --json
+```

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -1,6 +1,22 @@
 `box` operates on a **remote container**, not this machine. Your own file and shell
 tools act locally; anything that must happen inside the box goes through `box`.
 
+## Install
+
+```bash
+npm i -g @upstash/box-cli
+```
+
+## Authentication
+
+Every command needs an API key, or it fails with "API token required". Set it once,
+or pass `--token` on any single command. Create one at
+https://console.upstash.com/box.
+
+```bash
+export UPSTASH_BOX_API_KEY=box_...
+```
+
 ## Selecting a box
 
 Resolution order is `--box <id>`, then `$BOX_ID`, then the nearest `.box` file

--- a/skills/upstash/upstash-box-js/overview.md
+++ b/skills/upstash/upstash-box-js/overview.md
@@ -323,10 +323,15 @@ Clones land inside the box's isolated container, never on the caller's machine. 
 code is data until something runs it — treat an untrusted repo as untrusted input, and
 pair it with a restrictive `networkPolicy` (see below) before running its build or tests.
 
+Every git call except `clone` runs in the box's current directory, so `cd` into the
+clone first. At the workspace root there is no repository, and `status` comes back
+empty, which reads as a clean tree.
+
 ```ts
 await box.git.clone({ repo: "github.com/org/repo", branch: "main" })
 await box.git.clone({ repo: "github.com/org/repo", depth: 1 }) // shallow clone
-await box.cd("repo") // cd into cloned repo
+await box.git.clone({ repo: "github.com/org/repo", folder: "my-app" }) // destination
+await box.cd("repo") // the clone lands in a directory named after the repo
 
 const status = await box.git.status()
 const diff = await box.git.diff()
@@ -345,8 +350,8 @@ const pr = await box.git.createPR({ title: "Fix bug", body: "...", base: "main" 
 const cfg = await box.git.updateConfig({ userName: "Bot", userEmail: "bot@example.com" })
 // cfg: { git_user_name, git_user_email }
 
-// Arbitrary git commands
-const { output } = await box.git.exec({ args: ["log", "--oneline", "-5"] })
+// Arbitrary git commands. Check exit_code: 128 means the cwd is not a repository.
+const { output, exit_code } = await box.git.exec({ args: ["log", "--oneline", "-5"] })
 ```
 
 ## Schedules

--- a/skills/upstash/upstash-box-py/overview.md
+++ b/skills/upstash/upstash-box-py/overview.md
@@ -341,10 +341,15 @@ Clones land inside the box's isolated container, never on the caller's machine. 
 code is data until something runs it — treat an untrusted repo as untrusted input, and
 pair it with a restrictive `network_policy` (see below) before running its build or tests.
 
+Every git call except `clone` runs in the box's current directory, so `cd` into the
+clone first. At the workspace root there is no repository, and `status` comes back
+empty, which reads as a clean tree.
+
 ```python
 box.git.clone(repo="github.com/org/repo", branch="main")
 box.git.clone(repo="github.com/org/repo", depth=1)  # shallow clone
-box.cd("repo")  # cd into cloned repo
+box.git.clone(repo="github.com/org/repo", folder="my-app")  # destination
+box.cd("repo")  # the clone lands in a directory named after the repo
 
 status = box.git.status()
 diff = box.git.diff()


### PR DESCRIPTION
> **Do not merge until `@upstash/box-cli` publishes.** The new skill instructs agents to run `box exec`, `box files write -`, `box git status -C` and `box delete`, none of which exist in the currently published CLI (0.2.20). They land in upstash/box#231, which itself waits on upstash/box#230.

Adds a skill for driving a box from the terminal, and corrects what the two box SDK skills say about git.

## `upstash-box-cli` (new)

Covers the non-interactive surface: selecting a box, running commands, files, git, expose, the agent, and cleaning up afterwards.

It leads with the thing an agent has to understand before anything else — `box` operates on a **remote container**, while the agent's own file and shell tools act on the local machine. Everything else follows from that.

It also names the two traps that cost real time while testing:

- A background server dies with the command that started it. `box exec -- '( npm run dev & )'` survives; a plain `&` does not, and the exposed URL then 502s.
- `box create` without `--no-repl` opens an interactive REPL, which will hang a headless run.

## The two SDK skills

Both gain the same correction: every git call except `clone` runs in the box's current directory, so `cd` into the clone first. At the workspace root there is no repository and `status` comes back **empty**, which reads as a clean tree rather than as an error. That ambiguity is invisible from the method signatures and is exactly the kind of thing a skill exists to prevent — it cost me time in two separate pieces of work before I wrote it down.

The JS skill also documents `exit_code` on `git.exec()` and `folder` on `git.clone()`. The Python skill documents `folder` only, since its `git.exec()` returns a bare string and drops the exit code.

## Notes

- Generated bundle rebuilt; `npm run check` passes, so the output matches the sources.
- The CLI skill was validated by running headless coding agents against it with the Box MCP server disabled, so the CLI path was actually exercised rather than shadowed. Three scenarios completed using only `box` commands: clone/edit/branch/commit, write/serve/expose a preview URL, and a task ending in `box delete --yes`.
- That testing found a real CLI bug rather than a documentation one: agents type `git checkout -b`, which the CLI rejected. It now accepts `-b`, and the skill states that the branch is created either way.
