### PR TITLE
DX-2970: make skills discoverable on skills.sh and Gemini CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,6 @@ The build's pre-check also refuses to run while `skills/upstash/` has unstaged c
 
 skills.sh matches multi-word searches against each skill's `description` (single-word searches match the name). Keep descriptions long and intent-rich: what the SDK is, a "Use when…" list of concrete tasks, and the words users actually type (rate limiting, message queue, background jobs, vector database, session storage…). Never rename a skill to improve ranking — change the description instead. `description` must stay on one line and must not contain `: ` (the build script parses it with a regex, and YAML would otherwise need quoting).
 
-## Gemini CLI gallery
+## Gemini CLI extension
 
-`gemini-extension.json` at the root makes the repo a Gemini CLI extension. The gallery at geminicli.com/extensions crawls repos that carry the `gemini-cli-extension` GitHub topic and have a release tag, so when you change the skills in a way users should see, bump `version` in `gemini-extension.json` and push a matching `vX.Y.Z` tag.
+`gemini-extension.json` at the root makes the repo installable with `gemini extensions install https://github.com/upstash/skills` (it clones the default branch; no tag needed). Listing in the gallery at geminicli.com/extensions is crawler-only: the repo must carry the `gemini-cli-extension` GitHub topic and have a tag, and there is no publish command or submission form. We have not tagged this repo for that yet, so bump `version` in `gemini-extension.json` only when the skills change in a way users should see.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,11 @@ To change a sub-skill:
 CI runs `npm run check`, which fails if the generated output is stale. `check.mjs` asserts that `git status --porcelain` is empty after rebuilding, so it only passes on a fully clean tree — commit your source edits *and* the regenerated output before running it, otherwise it reports them as "out of date".
 
 The build's pre-check also refuses to run while `skills/upstash/` has unstaged changes — if you edited it by mistake, `git restore skills/upstash/` first.
+
+## Skill descriptions are the search index
+
+skills.sh matches multi-word searches against each skill's `description` (single-word searches match the name). Keep descriptions long and intent-rich: what the SDK is, a "Use when…" list of concrete tasks, and the words users actually type (rate limiting, message queue, background jobs, vector database, session storage…). Never rename a skill to improve ranking — change the description instead. `description` must stay on one line and must not contain `: ` (the build script parses it with a regex, and YAML would otherwise need quoting).
+
+## Gemini CLI gallery
+
+`gemini-extension.json` at the root makes the repo a Gemini CLI extension. The gallery at geminicli.com/extensions crawls repos that carry the `gemini-cli-extension` GitHub topic and have a release tag, so when you change the skills in a way users should see, bump `version` in `gemini-extension.json` and push a matching `vX.Y.Z` tag.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Upstash Agent Skills
 
+[![skills.sh](https://skills.sh/b/upstash/skills)](https://skills.sh/upstash/skills)
+
 A collection of skills for AI coding agents working with Upstash SDKs. Skills are packaged instructions and resources that extend agent capabilities.
 
-This repo works as an [Agent Skills](https://agentskills.io/) repo, a [Claude Code plugin](https://code.claude.com/docs/en/plugins), a [Cursor plugin](https://cursor.com/docs/plugins), an [OpenAI Codex plugin](https://developers.openai.com/codex/plugins/build), and a [DeepSeek Harness bundle](https://github.com/deepseek-ai/deepseek-harness). It also installs into [OpenCode](#opencode), [Zed](#zed), and any other Agent Skills-compatible client with `npx skills add`.
+This repo works as an [Agent Skills](https://agentskills.io/) repo, a [Claude Code plugin](https://code.claude.com/docs/en/plugins), a [Cursor plugin](https://cursor.com/docs/plugins), an [OpenAI Codex plugin](https://developers.openai.com/codex/plugins/build), and a [DeepSeek Harness bundle](https://github.com/deepseek-ai/deepseek-harness). It also installs into [OpenCode](#opencode), [Zed](#zed), [Gemini CLI](#gemini-cli), and any other Agent Skills-compatible client with `npx skills add`.
 
 ## Available Skills
 
@@ -83,6 +85,14 @@ The skills then show up in Zed's Agent Panel, and the agent can load them on its
 `/upstash`. Zed's extension marketplace carries languages, themes, debuggers, snippets, and MCP
 servers, but has no channel for skills, so the CLI is the only way to install them. The Zed
 extension in `zed-extension/` covers the [MCP server](#mcp-server) instead.
+
+### Gemini CLI
+
+Gemini CLI loads this repo as an [extension](https://geminicli.com/docs/extensions/) — the manifest is `gemini-extension.json` at the repo root, and every skill under `skills/` is picked up automatically:
+
+```bash
+gemini extensions install https://github.com/upstash/skills
+```
 
 ### Context7 CLI
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "upstash",
+  "version": "1.0.0",
+  "description": "Agent skills for all Upstash SDKs: Redis, Ratelimit, QStash, Workflow, Vector, Search, Box, and the Upstash CLI."
+}

--- a/scripts/header.md
+++ b/scripts/header.md
@@ -1,6 +1,10 @@
 ---
 name: upstash
-description: Work with any Upstash SDK or tool including Redis, Box (TypeScript/JavaScript and Python), QStash, Workflow, Vector, Search, Ratelimit and the Upstash CLI. Use when the user is working with any Upstash product or SDK.
+description: Work with any Upstash product, SDK, or tool, including serverless Redis (caching, sessions, leaderboards, key-value storage), Ratelimit (rate limiting and throttling), QStash (message queue, cron schedules, background jobs), Workflow (durable long-running functions), Vector (vector database for embeddings, semantic search, and RAG), Search (full-text and semantic search), Box (sandboxed cloud containers for AI agents, TypeScript/JavaScript and Python), the Upstash CLI, and no-signup scratch Redis for agents. Use when the user mentions Upstash or needs any of these capabilities in a serverless, edge, or Node.js app.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # Upstash Skills

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Start here",
+      "description": "The combined skill for every Upstash product, plus no-signup scratch Redis and the CLI.",
+      "skills": ["upstash", "upstash-redis-start", "upstash-cli"]
+    },
+    {
+      "title": "Caching, sessions, and rate limiting",
+      "description": "Serverless Redis for caching, session storage, leaderboards, and rate limiting from edge and serverless functions.",
+      "skills": ["upstash-redis-js", "upstash-ratelimit-js"]
+    },
+    {
+      "title": "Queues, background jobs, and workflows",
+      "description": "HTTP message queues, cron schedules, and durable multi-step workflows without a long-running worker.",
+      "skills": ["upstash-qstash-js", "upstash-workflow-js"]
+    },
+    {
+      "title": "Vector and search",
+      "description": "Vector database for embeddings and RAG, and full-text plus semantic search with reranking.",
+      "skills": ["upstash-vector-js", "upstash-search-js"]
+    },
+    {
+      "title": "Sandboxed containers for agents",
+      "description": "Upstash Box: cloud sandboxes with shell, filesystem, git, cron, snapshots, and a headless browser.",
+      "skills": ["upstash-box-js", "upstash-box-py"]
+    }
+  ]
+}

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -5,27 +5,43 @@
     {
       "title": "Start here",
       "description": "The combined skill for every Upstash product, plus no-signup scratch Redis and the CLI.",
-      "skills": ["upstash", "upstash-redis-start", "upstash-cli"]
+      "skills": [
+        "upstash",
+        "upstash-redis-start",
+        "upstash-cli"
+      ]
     },
     {
-      "title": "Caching, sessions, and rate limiting",
+      "title": "Redis: caching, sessions, and rate limiting",
       "description": "Serverless Redis for caching, session storage, leaderboards, and rate limiting from edge and serverless functions.",
-      "skills": ["upstash-redis-js", "upstash-ratelimit-js"]
+      "skills": [
+        "upstash-redis-js",
+        "upstash-ratelimit-js"
+      ]
     },
     {
       "title": "Queues, background jobs, and workflows",
       "description": "HTTP message queues, cron schedules, and durable multi-step workflows without a long-running worker.",
-      "skills": ["upstash-qstash-js", "upstash-workflow-js"]
+      "skills": [
+        "upstash-qstash-js",
+        "upstash-workflow-js"
+      ]
     },
     {
       "title": "Vector and search",
       "description": "Vector database for embeddings and RAG, and full-text plus semantic search with reranking.",
-      "skills": ["upstash-vector-js", "upstash-search-js"]
+      "skills": [
+        "upstash-vector-js",
+        "upstash-search-js"
+      ]
     },
     {
       "title": "Sandboxed containers for agents",
       "description": "Upstash Box: cloud sandboxes with shell, filesystem, git, cron, snapshots, and a headless browser.",
-      "skills": ["upstash-box-js", "upstash-box-py"]
+      "skills": [
+        "upstash-box-js",
+        "upstash-box-py"
+      ]
     }
   ]
 }

--- a/skills/upstash-box-js/SKILL.md
+++ b/skills/upstash-box-js/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-box-js
-description: Work with the @upstash/box TypeScript/JavaScript SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, and a headless browser. Use when building with Upstash Box, creating sandboxed environments, running AI agents in containers, browser automation from a box, or orchestrating parallel boxes.
+description: Work with the @upstash/box TypeScript/JavaScript SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, snapshots, and a headless browser. Use when building with Upstash Box, creating a sandbox or isolated environment to run untrusted or agent-generated code, running AI coding agents in containers, giving an agent a cloud dev environment with a shell and repository, browser automation from a box, scheduling recurring jobs inside a box, saving and restoring snapshots, or orchestrating parallel boxes.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # @upstash/box SDK

--- a/skills/upstash-box-py/SKILL.md
+++ b/skills/upstash-box-py/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-box-py
-description: Work with the upstash-box Python SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, and a headless browser. Use when building with Upstash Box in Python, creating sandboxed environments, running AI agents in containers, browser automation from a box, or orchestrating parallel boxes.
+description: Work with the upstash-box Python SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, snapshots, and a headless browser. Use when building with Upstash Box in Python, creating a sandbox or isolated environment to run untrusted or agent-generated code, running AI coding agents in containers, giving an agent a cloud dev environment with a shell and repository, browser automation from a box, scheduling recurring jobs inside a box, saving and restoring snapshots, or orchestrating parallel boxes.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # upstash-box Python SDK

--- a/skills/upstash-cli/SKILL.md
+++ b/skills/upstash-cli/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-cli
-description: Run the Upstash CLI (`upstash`) against the Upstash Developer API for Redis, Vector, Search, QStash, and teams. Use when listing or managing databases, backups, vector/search indexes, QStash instances, team members, stats, or any non-interactive Upstash automation with JSON output and terminal commands.
+description: Run the Upstash CLI (`upstash`) against the Upstash Developer API for Redis, Vector, Search, QStash, and teams, with non-interactive commands and JSON output for scripts, CI, and agents. Use when creating, listing, renaming, or deleting Redis databases, changing plans, regions, TLS, eviction, auto-upgrade, or budgets, managing backups, running Redis commands with `upstash redis exec`, creating or inspecting Vector and Search indexes, managing QStash instances and tokens, managing team members, reading usage stats, or automating any Upstash account operation from the terminal. Also use when the user asks how to provision or manage Upstash resources without the console.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 The Upstash CLI (`upstash`) manages Upstash services via the Upstash Developer API. All commands are non-interactive and emit JSON on stdout. Errors go to stderr as `{ "error": "..." }` with exit code `1`.

--- a/skills/upstash-qstash-js/SKILL.md
+++ b/skills/upstash-qstash-js/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-qstash-js
-description: Work with the QStash TypeScript/JavaScript SDK for serverless messaging, scheduling. Use when publishing messages to HTTP endpoints, creating schedules, managing queues, verifying incoming messages and other QStash features in serverless environments.
+description: Work with the @upstash/qstash TypeScript/JavaScript SDK, an HTTP-based message queue, task scheduler, and background job system for serverless and edge runtimes (Next.js, Vercel, Cloudflare Workers, Deno, Node.js). Use when publishing messages to HTTP endpoints or URL groups, running background jobs without a long-running worker process, scheduling with cron expressions, delaying messages, building FIFO queues with parallelism and flow control, configuring retries and callbacks, handling a dead letter queue (DLQ), deduplicating messages, fanning out to multiple endpoints, verifying QStash webhook signatures (Next.js App Router, Pages Router, and Edge Runtime), running a local QStash dev server, or migrating regions. Also use when the user asks for a serverless cron job, async task queue, job scheduler, delayed delivery, webhook delivery with retries, or event-driven messaging between services.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # QStash JavaScript SDK

--- a/skills/upstash-ratelimit-js/SKILL.md
+++ b/skills/upstash-ratelimit-js/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-ratelimit-js
-description: Lightweight guidance for using the Upstash Redis RateLimit TypeScript/JavaScript SDK, including setup steps, basic usage, and pointers to advanced algorithm, features, pricing, and traffic‑protection docs.
+description: Rate limiting for serverless and edge apps with the @upstash/ratelimit TypeScript/JavaScript SDK backed by Upstash Redis. Use when adding a rate limiter or throttling to an API route, Next.js middleware, Vercel Edge, Cloudflare Workers, or any HTTP endpoint; returning 429 Too Many Requests; choosing between fixed window, sliding window, and token bucket algorithms; limiting per user, IP, API key, or tenant with prefixes and custom keys; protecting login, signup, form, or AI endpoints from abuse, bots, and brute force; using deny lists, ephemeral caching, analytics, timeouts, and multi-region rate limits; or estimating the Redis command cost of rate limiting. Also use when the user says rate limit, rate-limiting, throttle, quota, request limits, or traffic protection.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # Rate Limit TS SDK

--- a/skills/upstash-redis-js/SKILL.md
+++ b/skills/upstash-redis-js/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-redis-js
-description: Work with the Upstash Redis TypeScript/JavaScript SDK for serverless Redis operations. Use for caching, session storage, rate limiting, leaderboards, full-text search (querying, filtering, aggregating) with Upstash Redis Search (different from regular FT.SEARCH), and all Redis data structures. Supports automatic serialization/deserialization of JavaScript types. Upstash Redis Search also available via @upstash/search-redis and @upstash/search-ioredis adapters for TCP clients.
+description: Work with the @upstash/redis TypeScript/JavaScript SDK, a serverless HTTP-based Redis client for Next.js, Vercel, Cloudflare Workers, edge runtimes, and Node.js. Use when adding a cache (cache-aside, write-through, TTL and expiration strategies), session storage and user sessions, a key-value store, leaderboards and rankings with sorted sets, counters, distributed locks, queues with lists, streams and consumer groups, JSON documents, pipelines and MULTI/EXEC transactions, Lua scripting, read replicas, or full-text search, typo-tolerant search, facets, and aggregations with Upstash Redis Search (different from regular FT.SEARCH; also available for TCP clients via @upstash/search-redis and @upstash/search-ioredis). Also use when migrating from ioredis or node-redis, when a Redis connection is needed from a serverless function without connection pooling, when integrating @upstash/ratelimit, or when the user says Redis cache, KV store, session store, serverless Redis, or Upstash Redis. Supports automatic serialization/deserialization of JavaScript types.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # Upstash Redis SDK - Complete Skills Guide

--- a/skills/upstash-redis-start/SKILL.md
+++ b/skills/upstash-redis-start/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-redis-start
-description: Provision a zero-config, no-signup Upstash Redis database for an AI agent via a single POST to `https://upstash.com/start-redis`. Use when an agent needs scratch Redis for short-term memory, conversation history, sub-agent work queues, or ranked recall and the user has not provided credentials. The database lives 3 days unless the user claims it.
+description: Provision a zero-config, no-signup, temporary Upstash Redis database for an AI agent with a single POST to https://upstash.com/start-redis, with no account, API key, or SDK setup required. Use when an agent needs scratch Redis right now and the user has not provided credentials, for short-term memory across tool calls, conversation history, a sub-agent work queue, ranked recall, or a quick prototype or demo. Covers idempotent creation and re-fetching credentials, calling the database through the body-style REST API or the official SDKs, and telling the user how to claim it. The database lives 3 days unless the user claims it; not for production data, PII, or secrets.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # Upstash Redis for Agents (`start-redis`)

--- a/skills/upstash-search-js/SKILL.md
+++ b/skills/upstash-search-js/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-search-js
-description: Skills covering Upstash Search quick starts, core concepts, and TypeScript/JavaScript SDK usage. Use when a user asks how to get started, how indexing works, or how to use the TS client.
+description: Work with the @upstash/search TypeScript/JavaScript SDK, a serverless full-text and semantic search database with built-in reranking. Use when adding search to an app or site, creating a search index, upserting documents with searchable content and filterable metadata, running keyword, semantic, or hybrid search queries, reranking results, filtering with SQL-like or structured filter syntax, paginating with range, fetching or deleting documents, resetting an index, or checking index info. Also use when the user asks for site search, product, document, or knowledge-base search, or a managed search service that needs no cluster to run.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # Upstash Search Documentation

--- a/skills/upstash-vector-js/SKILL.md
+++ b/skills/upstash-vector-js/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-vector-js
-description: Skills for Upstash Vector features, TypeScript/JavaScript SDK usage, and integrations. Use when users ask how to work with Vector, its TS SDK, features, or supported frameworks.
+description: Work with the @upstash/vector TypeScript/JavaScript SDK, a serverless vector database for embeddings, similarity search, semantic search, and RAG (retrieval-augmented generation). Use when upserting, querying, fetching, ranging, or deleting vectors, upserting raw text against an index with a built-in embedding model, choosing dense, sparse, or hybrid indexes, filtering by metadata, organizing data with namespaces, running resumable queries, or connecting Upstash Vector to an AI or LLM application. Also use when the user asks for a vector store, vector search, nearest-neighbor or kNN search, embeddings storage, semantic cache, recommendations or similarity features, or a hosted vector index that needs no infrastructure.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # Vector Documentation Skill

--- a/skills/upstash-workflow-js/SKILL.md
+++ b/skills/upstash-workflow-js/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash-workflow-js
-description: Skills for the Upstash Workflow TypeScript/JavaScript SDK to define, trigger, and manage workflows. Use this Skill whenever a user wants to create workflow endpoints, run steps, or interact with the Upstash Workflow client.
+description: Work with the @upstash/workflow TypeScript/JavaScript SDK for durable, long-running workflows in serverless functions, multi-step processes that survive timeouts, retries, and restarts (built on QStash). Use when defining a workflow endpoint with serve(), running steps with context.run, sleeping for minutes to days without holding a function open, calling external APIs with context.call, waiting for an external event or webhook, invoking other workflows, configuring retries, failure callbacks, and a DLQ, controlling concurrency, rate, and parallelism, triggering, cancelling, or inspecting runs with the Workflow client, building AI agents and orchestrators, human-in-the-loop approvals, realtime updates, local development with the QStash dev server, adding middleware, or migrating workflows safely. Also use when the user asks for durable execution, step functions, saga or orchestration patterns, background jobs with checkpoints, or long-running tasks on Vercel, Next.js, Cloudflare Workers, or other serverless platforms.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # Upstash Workflow SDK

--- a/skills/upstash/SKILL.md
+++ b/skills/upstash/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: upstash
-description: Work with any Upstash SDK or tool including Redis, Box (TypeScript/JavaScript and Python), QStash, Workflow, Vector, Search, Ratelimit and the Upstash CLI. Use when the user is working with any Upstash product or SDK.
+description: Work with any Upstash product, SDK, or tool, including serverless Redis (caching, sessions, leaderboards, key-value storage), Ratelimit (rate limiting and throttling), QStash (message queue, cron schedules, background jobs), Workflow (durable long-running functions), Vector (vector database for embeddings, semantic search, and RAG), Search (full-text and semantic search), Box (sandboxed cloud containers for AI agents, TypeScript/JavaScript and Python), the Upstash CLI, and no-signup scratch Redis for agents. Use when the user mentions Upstash or needs any of these capabilities in a serverless, edge, or Node.js app.
+license: MIT
+metadata:
+  author: Upstash
+  homepage: https://upstash.com
 ---
 
 # Upstash Skills
@@ -9,40 +13,40 @@ This skill combines documentation for all Upstash SDKs. Pick the relevant sub-sk
 
 ## [upstash-box-js](upstash-box-js/overview.md)
 
-Work with the @upstash/box TypeScript/JavaScript SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, and a headless browser. Use when building with Upstash Box, creating sandboxed environments, running AI agents in containers, browser automation from a box, or orchestrating parallel boxes.
+Work with the @upstash/box TypeScript/JavaScript SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, snapshots, and a headless browser. Use when building with Upstash Box, creating a sandbox or isolated environment to run untrusted or agent-generated code, running AI coding agents in containers, giving an agent a cloud dev environment with a shell and repository, browser automation from a box, scheduling recurring jobs inside a box, saving and restoring snapshots, or orchestrating parallel boxes.
 
 ## [upstash-box-py](upstash-box-py/overview.md)
 
-Work with the upstash-box Python SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, and a headless browser. Use when building with Upstash Box in Python, creating sandboxed environments, running AI agents in containers, browser automation from a box, or orchestrating parallel boxes.
+Work with the upstash-box Python SDK for sandboxed cloud containers with AI agents, shell, filesystem, git, cron schedules, snapshots, and a headless browser. Use when building with Upstash Box in Python, creating a sandbox or isolated environment to run untrusted or agent-generated code, running AI coding agents in containers, giving an agent a cloud dev environment with a shell and repository, browser automation from a box, scheduling recurring jobs inside a box, saving and restoring snapshots, or orchestrating parallel boxes.
 
 ## [upstash-cli](upstash-cli/overview.md)
 
-Run the Upstash CLI (`upstash`) against the Upstash Developer API for Redis, Vector, Search, QStash, and teams. Use when listing or managing databases, backups, vector/search indexes, QStash instances, team members, stats, or any non-interactive Upstash automation with JSON output and terminal commands.
+Run the Upstash CLI (`upstash`) against the Upstash Developer API for Redis, Vector, Search, QStash, and teams, with non-interactive commands and JSON output for scripts, CI, and agents. Use when creating, listing, renaming, or deleting Redis databases, changing plans, regions, TLS, eviction, auto-upgrade, or budgets, managing backups, running Redis commands with `upstash redis exec`, creating or inspecting Vector and Search indexes, managing QStash instances and tokens, managing team members, reading usage stats, or automating any Upstash account operation from the terminal. Also use when the user asks how to provision or manage Upstash resources without the console.
 
 ## [upstash-qstash-js](upstash-qstash-js/overview.md)
 
-Work with the QStash TypeScript/JavaScript SDK for serverless messaging, scheduling. Use when publishing messages to HTTP endpoints, creating schedules, managing queues, verifying incoming messages and other QStash features in serverless environments.
+Work with the @upstash/qstash TypeScript/JavaScript SDK, an HTTP-based message queue, task scheduler, and background job system for serverless and edge runtimes (Next.js, Vercel, Cloudflare Workers, Deno, Node.js). Use when publishing messages to HTTP endpoints or URL groups, running background jobs without a long-running worker process, scheduling with cron expressions, delaying messages, building FIFO queues with parallelism and flow control, configuring retries and callbacks, handling a dead letter queue (DLQ), deduplicating messages, fanning out to multiple endpoints, verifying QStash webhook signatures (Next.js App Router, Pages Router, and Edge Runtime), running a local QStash dev server, or migrating regions. Also use when the user asks for a serverless cron job, async task queue, job scheduler, delayed delivery, webhook delivery with retries, or event-driven messaging between services.
 
 ## [upstash-ratelimit-js](upstash-ratelimit-js/overview.md)
 
-Lightweight guidance for using the Upstash Redis RateLimit TypeScript/JavaScript SDK, including setup steps, basic usage, and pointers to advanced algorithm, features, pricing, and traffic‑protection docs.
+Rate limiting for serverless and edge apps with the @upstash/ratelimit TypeScript/JavaScript SDK backed by Upstash Redis. Use when adding a rate limiter or throttling to an API route, Next.js middleware, Vercel Edge, Cloudflare Workers, or any HTTP endpoint; returning 429 Too Many Requests; choosing between fixed window, sliding window, and token bucket algorithms; limiting per user, IP, API key, or tenant with prefixes and custom keys; protecting login, signup, form, or AI endpoints from abuse, bots, and brute force; using deny lists, ephemeral caching, analytics, timeouts, and multi-region rate limits; or estimating the Redis command cost of rate limiting. Also use when the user says rate limit, rate-limiting, throttle, quota, request limits, or traffic protection.
 
 ## [upstash-redis-js](upstash-redis-js/overview.md)
 
-Work with the Upstash Redis TypeScript/JavaScript SDK for serverless Redis operations. Use for caching, session storage, rate limiting, leaderboards, full-text search (querying, filtering, aggregating) with Upstash Redis Search (different from regular FT.SEARCH), and all Redis data structures. Supports automatic serialization/deserialization of JavaScript types. Upstash Redis Search also available via @upstash/search-redis and @upstash/search-ioredis adapters for TCP clients.
+Work with the @upstash/redis TypeScript/JavaScript SDK, a serverless HTTP-based Redis client for Next.js, Vercel, Cloudflare Workers, edge runtimes, and Node.js. Use when adding a cache (cache-aside, write-through, TTL and expiration strategies), session storage and user sessions, a key-value store, leaderboards and rankings with sorted sets, counters, distributed locks, queues with lists, streams and consumer groups, JSON documents, pipelines and MULTI/EXEC transactions, Lua scripting, read replicas, or full-text search, typo-tolerant search, facets, and aggregations with Upstash Redis Search (different from regular FT.SEARCH; also available for TCP clients via @upstash/search-redis and @upstash/search-ioredis). Also use when migrating from ioredis or node-redis, when a Redis connection is needed from a serverless function without connection pooling, when integrating @upstash/ratelimit, or when the user says Redis cache, KV store, session store, serverless Redis, or Upstash Redis. Supports automatic serialization/deserialization of JavaScript types.
 
 ## [upstash-redis-start](upstash-redis-start/overview.md)
 
-Provision a zero-config, no-signup Upstash Redis database for an AI agent via a single POST to `https://upstash.com/start-redis`. Use when an agent needs scratch Redis for short-term memory, conversation history, sub-agent work queues, or ranked recall and the user has not provided credentials. The database lives 3 days unless the user claims it.
+Provision a zero-config, no-signup, temporary Upstash Redis database for an AI agent with a single POST to https://upstash.com/start-redis, with no account, API key, or SDK setup required. Use when an agent needs scratch Redis right now and the user has not provided credentials, for short-term memory across tool calls, conversation history, a sub-agent work queue, ranked recall, or a quick prototype or demo. Covers idempotent creation and re-fetching credentials, calling the database through the body-style REST API or the official SDKs, and telling the user how to claim it. The database lives 3 days unless the user claims it; not for production data, PII, or secrets.
 
 ## [upstash-search-js](upstash-search-js/overview.md)
 
-Skills covering Upstash Search quick starts, core concepts, and TypeScript/JavaScript SDK usage. Use when a user asks how to get started, how indexing works, or how to use the TS client.
+Work with the @upstash/search TypeScript/JavaScript SDK, a serverless full-text and semantic search database with built-in reranking. Use when adding search to an app or site, creating a search index, upserting documents with searchable content and filterable metadata, running keyword, semantic, or hybrid search queries, reranking results, filtering with SQL-like or structured filter syntax, paginating with range, fetching or deleting documents, resetting an index, or checking index info. Also use when the user asks for site search, product, document, or knowledge-base search, or a managed search service that needs no cluster to run.
 
 ## [upstash-vector-js](upstash-vector-js/overview.md)
 
-Skills for Upstash Vector features, TypeScript/JavaScript SDK usage, and integrations. Use when users ask how to work with Vector, its TS SDK, features, or supported frameworks.
+Work with the @upstash/vector TypeScript/JavaScript SDK, a serverless vector database for embeddings, similarity search, semantic search, and RAG (retrieval-augmented generation). Use when upserting, querying, fetching, ranging, or deleting vectors, upserting raw text against an index with a built-in embedding model, choosing dense, sparse, or hybrid indexes, filtering by metadata, organizing data with namespaces, running resumable queries, or connecting Upstash Vector to an AI or LLM application. Also use when the user asks for a vector store, vector search, nearest-neighbor or kNN search, embeddings storage, semantic cache, recommendations or similarity features, or a hosted vector index that needs no infrastructure.
 
 ## [upstash-workflow-js](upstash-workflow-js/overview.md)
 
-Skills for the Upstash Workflow TypeScript/JavaScript SDK to define, trigger, and manage workflows. Use this Skill whenever a user wants to create workflow endpoints, run steps, or interact with the Upstash Workflow client.
+Work with the @upstash/workflow TypeScript/JavaScript SDK for durable, long-running workflows in serverless functions, multi-step processes that survive timeouts, retries, and restarts (built on QStash). Use when defining a workflow endpoint with serve(), running steps with context.run, sleeping for minutes to days without holding a function open, calling external APIs with context.call, waiting for an external event or webhook, invoking other workflows, configuring retries, failure callbacks, and a DLQ, controlling concurrency, rate, and parallelism, triggering, cancelling, or inspecting runs with the Workflow client, building AI agents and orchestrators, human-in-the-loop approvals, realtime updates, local development with the QStash dev server, adding middleware, or migrating workflows safely. Also use when the user asks for durable execution, step functions, saga or orchestration patterns, background jobs with checkpoints, or long-running tasks on Vercel, Next.js, Cloudflare Workers, or other serverless platforms.


### PR DESCRIPTION
Summary

skills.sh matches multi-word searches against each skill's description (single-word searches match the name only), and there is no tags/keywords mechanism. Our descriptions were the shortest in the category and never said "rate limiting", "message queue", "background jobs", "vector database", or "session storage", so Upstash was absent from 11 of 16 problem-word searches while 1-install skills ranked. This rewrites every description for intent (names unchanged), adds the frontmatter every competitor carries, groups the repo page, and makes the repo a Gemini CLI extension.

Changes

- Rewrote the 10 sub-skill descriptions (540–1,066 chars each) as what-it-is → "Use when…" tasks → the words users type; every claim checked against the skill files. Combined upstash skill description updated via scripts/header.md; skills/upstash/ regenerated.
- Added license: MIT and metadata: {author, homepage} to all 11 SKILL.md frontmatters.
- skills.sh.json: five repo-page groups (Start here / Caching, sessions, rate limiting / Queues, background jobs, workflows / Vector and search / Sandboxed containers).
- gemini-extension.json at the root; README gains a Gemini CLI install section and the skills.sh badge; AGENTS.md documents the description-as-search-index rule and the gallery release steps.

Testing

All frontmatter parsed with PyYAML and Ruby YAML; npm run check passes (generated skills/upstash/ is in sync)