### PR TITLE
DX-2996 wire the remote Upstash MCP into the plugin manifests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,13 @@
 {
   "name": "upstash",
   "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search.",
-  "version": "1.0.0",
+  "version": "1.1.0",
+  "mcpServers": {
+    "upstash": {
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
+    }
+  },
   "author": {
     "name": "Upstash",
     "email": "support@upstash.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,12 @@
 {
   "name": "upstash",
-  "version": "1.0.0",
+  "version": "1.1.0",
+  "mcpServers": {
+    "upstash": {
+      "type": "http",
+      "url": "https://mcp.upstash.com/mcp"
+    }
+  },
   "description": "Agent skills for all Upstash SDKs — Redis, QStash, Workflow, Box, Ratelimit, Vector, and Search.",
   "author": {
     "name": "Upstash",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,12 @@
 {
   "name": "upstash",
   "description": "Agent skills for Upstash SDKs and CLIs — Redis, QStash, Workflow, Box (SDKs and the box CLI), Ratelimit, Vector, and Search.",
-  "version": "1.0.0",
+  "version": "1.1.0",
+  "mcpServers": {
+    "upstash": {
+      "url": "https://mcp.upstash.com/mcp"
+    }
+  },
   "author": {
     "name": "Upstash",
     "email": "support@upstash.com"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # Upstash Agent Skills
 
-A collection of skills for AI coding agents working with Upstash SDKs and CLIs. Skills are packaged instructions and resources that extend agent capabilities.
+Connect your AI coding agent to Upstash. This repo ships **skills** (per-SDK instruction packs your agent loads on demand) and the **plugin manifests** that install them — and now the **Upstash MCP server** — into Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Zed, and any Agent Skills–compatible client.
 
-This repo works as an [Agent Skills](https://agentskills.io/) repo, a [Claude Code plugin](https://code.claude.com/docs/en/plugins), a [Cursor plugin](https://cursor.com/docs/plugins), an [OpenAI Codex plugin](https://developers.openai.com/codex/plugins/build), and a [DeepSeek Harness bundle](https://github.com/deepseek-ai/deepseek-harness). It also installs into [OpenCode](#opencode), [Zed](#zed), [Gemini CLI](#gemini-cli), and any other Agent Skills-compatible client with `npx skills add`.
+## The Upstash agent surface
+
+- **Skills** — packaged instructions and CLI references for each Upstash SDK (Redis, QStash, Workflow, Vector, Search, Box, Ratelimit). No credentials needed. → [docs](https://upstash.com/docs/agent-resources/skills)
+- **MCP server** — live tools to query, debug, and manage your account. Two ways to run it:
+  - **Remote (hosted)** — `https://mcp.upstash.com/mcp`, streamable HTTP, authenticated with OAuth (browser consent, on first use) or a developer API key header. Nothing to install.
+  - **Local (stdio)** — [`@upstash/mcp-server`](https://www.npmjs.com/package/@upstash/mcp-server) run with `npx`, authenticated with your account email + a developer API key.
+
+  → [docs](https://upstash.com/docs/agent-resources/mcp)
+- New here? Start with the [AI Tools overview](https://upstash.com/docs/agent-resources/overview), and see [Install by agent](https://upstash.com/docs/agent-resources/clients) for full per-client setup.
+
+## What's in this repo
+
+- **`skills/upstash-*/`** — the per-SDK skill sources (each has a `SKILL.md`). Edit these.
+- **`skills/upstash/`** — the combined skill, **generated** from all the sources by `npm run build`. Never hand-edit it (see [`AGENTS.md`](AGENTS.md)).
+- **Plugin manifests** — `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`, `gemini-extension.json`, and the portable [Agent Plugins](https://agent-plugins.org) `plugin.json` + `mcp.json`. They make the repo installable as a plugin/extension. **These plugins now bundle the remote Upstash MCP server (OAuth), so installing the plugin sets up the skills *and* the MCP in one step** — no separate MCP configuration for Claude Code, Codex, Cursor, or Gemini CLI.
+- **`zed-extension/`** — a Zed MCP server extension (Rust → Wasm).
 
 ## Available Skills
 
@@ -21,9 +36,13 @@ This repo works as an [Agent Skills](https://agentskills.io/) repo, a [Claude Co
 | [upstash-vector-js](skills/upstash-vector-js/) | Vector database features, SDK usage, and framework integrations. |
 | [upstash-workflow-js](skills/upstash-workflow-js/) | Durable workflows — define, trigger, and manage multi-step processes. |
 
-## Installation
+## Install
 
-### Claude Code Plugin
+Installing through a **plugin** (Claude Code, Codex, Cursor, Gemini CLI) sets up both the skills and the remote MCP server — approve the MCP's OAuth consent on first use. The skills-only installers (Agent Skills CLI, OpenCode, Zed) install skills; add the [MCP server](#mcp-server) separately if you want live account access.
+
+For the full, up-to-date per-client instructions, see [Install by agent](https://upstash.com/docs/agent-resources/clients).
+
+### Claude Code (skills + MCP)
 
 ```bash
 # Add the marketplace
@@ -33,13 +52,7 @@ This repo works as an [Agent Skills](https://agentskills.io/) repo, a [Claude Co
 /plugin install upstash@upstash
 ```
 
-### Cursor Plugin
-
-We are waiting for this plugin to be accepted to the official
-[Cursor Marketplace](https://cursor.com/marketplace). Once listed, it can be installed
-from **Customize** in the Cursor sidebar.
-
-### OpenAI Codex Plugin
+### OpenAI Codex (skills + MCP)
 
 ```bash
 # Add the marketplace
@@ -47,6 +60,20 @@ codex plugin marketplace add upstash/skills
 
 # Install the plugin
 codex plugin add upstash@upstash
+```
+
+### Cursor (skills + MCP)
+
+We are waiting for this plugin to be accepted to the official
+[Cursor Marketplace](https://cursor.com/marketplace). Once listed, it can be installed
+from **Customize** in the Cursor sidebar, and it brings both the skills and the MCP server.
+
+### Gemini CLI (skills + MCP)
+
+Gemini CLI loads this repo as an [extension](https://geminicli.com/docs/extensions/) — the manifest is `gemini-extension.json` at the repo root; every skill under `skills/` and the remote MCP server are picked up automatically:
+
+```bash
+gemini extensions install https://github.com/upstash/skills
 ```
 
 ### OpenCode
@@ -85,14 +112,6 @@ The skills then show up in Zed's Agent Panel, and the agent can load them on its
 servers, but has no channel for skills, so the CLI is the only way to install them. The Zed
 extension in `zed-extension/` covers the [MCP server](#mcp-server) instead.
 
-### Gemini CLI
-
-Gemini CLI loads this repo as an [extension](https://geminicli.com/docs/extensions/) — the manifest is `gemini-extension.json` at the repo root, and every skill under `skills/` is picked up automatically:
-
-```bash
-gemini extensions install https://github.com/upstash/skills
-```
-
 ### Context7 CLI
 
 ```bash
@@ -129,7 +148,70 @@ soon as both are set. The skills work without them.
 
 ## MCP Server
 
-For full access to Upstash APIs (create databases, publish messages, query vectors, etc.), you can also set up the [`@upstash/mcp-server`](https://www.npmjs.com/package/@upstash/mcp-server):
+Installing a plugin above already wires up the remote MCP server. Set it up on its own when you
+use a skills-only installer (OpenCode, Zed) or a client without a plugin.
+
+**Remote (recommended)** — no install; OAuth on first use, or pass a developer API key header
+(`email:API_KEY`) for headless/CI. Create a key at
+[Console → Account → API Keys](https://console.upstash.com/account/api).
+
+<details>
+<summary>Claude Code</summary>
+
+```bash
+# OAuth (browser consent on first /mcp use)
+claude mcp add --transport http upstash https://mcp.upstash.com/mcp
+
+# Or a developer API key, no browser
+claude mcp add --transport http upstash https://mcp.upstash.com/mcp \
+  --header "Authorization: Bearer you@example.com:YOUR_API_KEY"
+```
+
+</details>
+
+<details>
+<summary>Cursor</summary>
+
+Add to `~/.cursor/mcp.json` (add `headers` with the `Authorization` line for the API-key path):
+
+```json
+{
+  "mcpServers": {
+    "upstash": { "url": "https://mcp.upstash.com/mcp" }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>OpenCode</summary>
+
+Add to `opencode.json`, or `~/.config/opencode/opencode.json` to make it available everywhere.
+See the [OpenCode MCP docs](https://opencode.ai/docs/mcp-servers).
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "upstash": {
+      "type": "remote",
+      "url": "https://mcp.upstash.com/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+</details>
+
+Scope which product tools the agent sees by appending `?features=` to the URL — comma-separated
+from `redis`, `qstash_workflow`, `vector`, `search` (omitted means all), e.g.
+`https://mcp.upstash.com/mcp?features=redis,qstash_workflow`.
+
+**Local (stdio)** — run [`@upstash/mcp-server`](https://www.npmjs.com/package/@upstash/mcp-server)
+yourself, authenticated with your email + API key. Read-only keys are supported (the server then
+disables every state-changing tool).
 
 <details>
 <summary>Claude Code</summary>
@@ -160,9 +242,6 @@ Add to `.cursor/mcp.json`:
 
 <details>
 <summary>OpenCode</summary>
-
-Add to `opencode.json` in your project, or to `~/.config/opencode/opencode.json` to make it
-available everywhere. See the [OpenCode MCP docs](https://opencode.ai/docs/mcp-servers) for more info.
 
 ```json
 {
@@ -204,12 +283,6 @@ To skip the extension entirely, add the server to your Zed settings by hand
 
 </details>
 
-<details>
-<summary>DeepSeek Harness</summary>
-
-Already included in the bundle — see [DeepSeek Harness](#deepseek-harness) above.
-</details>
-
 ## Making changes
 
 ### Updating an existing skill
@@ -231,7 +304,7 @@ The frontmatter and introductory text for `skills/upstash/SKILL.md` comes from `
 
 ### Updating the plugin version
 
-When making a release, bump the `version` field in every manifest that carries one: `plugin.json` (the portable [Agent Plugins](https://agent-plugins.org) manifest), `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and `.codex-plugin/plugin.json`.
+When making a release, bump the `version` field in every manifest that carries one: `plugin.json` (the portable [Agent Plugins](https://agent-plugins.org) manifest), `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `gemini-extension.json`.
 
 ### The Zed extension
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,10 @@
 {
   "name": "upstash",
-  "version": "1.0.0",
+  "version": "1.1.0",
+  "mcpServers": {
+    "upstash": {
+      "httpUrl": "https://mcp.upstash.com/mcp"
+    }
+  },
   "description": "Agent skills for all Upstash SDKs: Redis, Ratelimit, QStash, Workflow, Vector, Search, Box, and the Upstash CLI."
 }

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "upstash": {
+      "type": "streamable-http",
+      "url": "https://mcp.upstash.com/mcp"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "upstash",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Agent skills for Upstash SDKs and CLIs — Redis, QStash, Workflow, Box (SDKs and the box CLI), Ratelimit, Vector, and Search.",
   "author": {
     "name": "Upstash",


### PR DESCRIPTION
Rather than a new skill, this declares the hosted **remote** Upstash MCP server (`https://mcp.upstash.com/mcp`, streamable HTTP, OAuth on first use — no credentials in the manifest) in each client's plugin manifest, so installing the plugin also registers the MCP server.

Each client uses a different field/shape, verified against that client's schema:

| Client | File | Field | Shape |
|--------|------|-------|-------|
| Claude Code | `.claude-plugin/plugin.json` | `mcpServers` | `{ "type": "http", "url": … }` |
| OpenAI Codex | `.codex-plugin/plugin.json` | `mcpServers` | `{ "type": "http", "url": … }` |
| Cursor | `.cursor-plugin/plugin.json` | `mcpServers` | `{ "url": … }` (no `type`) |
| Gemini CLI | `gemini-extension.json` | `mcpServers` | `{ "httpUrl": … }` (not `url`) |
| Agent Plugins | `mcp.json` (sibling of `plugin.json`) | `mcpServers` | `{ "type": "streamable-http", "url": … }` |

The agent-plugins.org `plugin.json` schema has **no** `mcpServers` field, so its MCP declaration goes in a sibling `mcp.json` per the spec (the root `plugin.json` only gets a version bump).

### Schema references (to verify each manifest)
- Claude Code plugin: https://code.claude.com/docs/en/plugins-reference
- Cursor plugin: https://cursor.com/docs/reference/plugins
- OpenAI Codex plugin: https://github.com/openai/codex/blob/main/codex-rs/skills/src/assets/samples/plugin-creator/references/plugin-json-spec.md
- Gemini CLI (MCP servers): https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md
- Agent Plugins `mcp.json` schema: https://agent-plugins.org/schemas/1.0.0/mcp.schema.json

https://claude.ai/code/session_018mhLhJnvV8APHJfj2bF3gz