### PR TITLE
DX-2996 steer skills to the MCP first, CLI second

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,24 @@ CI runs `npm run check`, which fails if the generated output is stale. `check.mj
 
 The build's pre-check also refuses to run while `skills/upstash/` has unstaged changes — if you edited it by mistake, `git restore skills/upstash/` first.
 
+## MCP first, CLI second
+
+The plugins now install the hosted MCP server alongside the skills, so for
+account and data operations the agent usually has authenticated tools already
+in the session — creating and inspecting databases and indexes, running Redis
+commands, stats, logs, backups, QStash schedules and the DLQ. The CLI covers
+the same ground but needs a global npm install, a login and an API key.
+
+So `skills/upstash-cli/` opens by telling the agent to prefer the MCP when its
+tools are present and to fall back to the CLI for shell work — CI steps,
+provisioning scripts, piping JSON — and `scripts/header.md` says the same in
+the combined skill's routing preamble. Keep that ordering when editing either
+one, and do not add CLI instructions to an SDK skill that would pull an agent
+away from the MCP.
+
+The SDK skills are unaffected. They are about writing application code, which
+the MCP does not do.
+
 ## Skill descriptions are the search index
 
 skills.sh matches multi-word searches against each skill's `description` (single-word searches match the name). Keep descriptions long and intent-rich: what the SDK is, a "Use when…" list of concrete tasks, and the words users actually type (rate limiting, message queue, background jobs, vector database, session storage…). Never rename a skill to improve ranking — change the description instead. `description` must stay on one line and must not contain `: ` (the build script parses it with a regex, and YAML would otherwise need quoting).

--- a/scripts/header.md
+++ b/scripts/header.md
@@ -10,3 +10,8 @@ metadata:
 # Upstash Skills
 
 This skill combines documentation for all Upstash SDKs. Pick the relevant sub-skill below.
+
+If Upstash MCP tools are available in this session, prefer them for account and data operations —
+creating and inspecting databases and indexes, running Redis commands, reading stats, logs and the
+DLQ. The sub-skills below are for writing application code; reach for `upstash-cli` only when there
+is no MCP or the work is inherently shell work.

--- a/skills/upstash-cli/SKILL.md
+++ b/skills/upstash-cli/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: upstash-cli
-description: Run the Upstash CLI (`upstash`) against the Upstash Developer API for Redis, Vector, Search, QStash, and teams, with non-interactive commands and JSON output for scripts, CI, and agents. Use when creating, listing, renaming, or deleting Redis databases, changing plans, regions, TLS, eviction, auto-upgrade, or budgets, managing backups, running Redis commands with `upstash redis exec`, creating or inspecting Vector and Search indexes, managing QStash instances and tokens, managing team members, reading usage stats, or automating any Upstash account operation from the terminal. Also use when the user asks how to provision or manage Upstash resources without the console.
+description: Run the Upstash CLI (`upstash`) against the Upstash Developer API for Redis, Vector, Search, QStash, and teams, with non-interactive commands and JSON output for scripts, CI, and agents. Use when creating, listing, renaming, or deleting Redis databases, changing plans, regions, TLS, eviction, auto-upgrade, or budgets, managing backups, running Redis commands with `upstash redis exec`, creating or inspecting Vector and Search indexes, managing QStash instances and tokens, managing team members, reading usage stats, or automating any Upstash account operation from the terminal. Also use when the user asks how to provision or manage Upstash resources without the console. Prefer the Upstash MCP server when its tools are available in the session, and use this skill for terminal, CI, and scripting work.
 license: MIT
 metadata:
   author: Upstash
   homepage: https://upstash.com
 ---
+
+## Prefer the MCP server when it is available
+
+If Upstash MCP tools are in the session, call them instead of shelling out to the CLI. They are
+already authenticated and cover the same ground — creating and inspecting Redis databases, running
+Redis commands, usage stats, backups, Vector and Search indexes, QStash schedules and messages, the
+DLQ, and logs. Installing the Upstash plugin registers the hosted server at
+`https://mcp.upstash.com/mcp`.
+
+Use the CLI when there is no MCP in the session, or when the work is inherently shell work — a CI
+step, a provisioning script, or piping JSON into other commands.
 
 The Upstash CLI (`upstash`) manages Upstash services via the Upstash Developer API. All commands are non-interactive and emit JSON on stdout. Errors go to stderr as `{ "error": "..." }` with exit code `1`.
 

--- a/skills/upstash/SKILL.md
+++ b/skills/upstash/SKILL.md
@@ -11,6 +11,11 @@ metadata:
 
 This skill combines documentation for all Upstash SDKs. Pick the relevant sub-skill below.
 
+If Upstash MCP tools are available in this session, prefer them for account and data operations —
+creating and inspecting databases and indexes, running Redis commands, reading stats, logs and the
+DLQ. The sub-skills below are for writing application code; reach for `upstash-cli` only when there
+is no MCP or the work is inherently shell work.
+
 ## [upstash-box-cli](upstash-box-cli/overview.md)
 
 Drive an Upstash Box (a remote sandboxed workspace) from the terminal with the `box` CLI. Use when asked to run commands, edit files, clone repos, run builds or tests, publish a public URL, or do any work inside a box rather than on this machine.
@@ -25,7 +30,7 @@ Work with the upstash-box Python SDK for sandboxed cloud containers with AI agen
 
 ## [upstash-cli](upstash-cli/overview.md)
 
-Run the Upstash CLI (`upstash`) against the Upstash Developer API for Redis, Vector, Search, QStash, and teams, with non-interactive commands and JSON output for scripts, CI, and agents. Use when creating, listing, renaming, or deleting Redis databases, changing plans, regions, TLS, eviction, auto-upgrade, or budgets, managing backups, running Redis commands with `upstash redis exec`, creating or inspecting Vector and Search indexes, managing QStash instances and tokens, managing team members, reading usage stats, or automating any Upstash account operation from the terminal. Also use when the user asks how to provision or manage Upstash resources without the console.
+Run the Upstash CLI (`upstash`) against the Upstash Developer API for Redis, Vector, Search, QStash, and teams, with non-interactive commands and JSON output for scripts, CI, and agents. Use when creating, listing, renaming, or deleting Redis databases, changing plans, regions, TLS, eviction, auto-upgrade, or budgets, managing backups, running Redis commands with `upstash redis exec`, creating or inspecting Vector and Search indexes, managing QStash instances and tokens, managing team members, reading usage stats, or automating any Upstash account operation from the terminal. Also use when the user asks how to provision or manage Upstash resources without the console. Prefer the Upstash MCP server when its tools are available in the session, and use this skill for terminal, CI, and scripting work.
 
 ## [upstash-qstash-js](upstash-qstash-js/overview.md)
 

--- a/skills/upstash/upstash-cli/overview.md
+++ b/skills/upstash/upstash-cli/overview.md
@@ -1,3 +1,14 @@
+## Prefer the MCP server when it is available
+
+If Upstash MCP tools are in the session, call them instead of shelling out to the CLI. They are
+already authenticated and cover the same ground — creating and inspecting Redis databases, running
+Redis commands, usage stats, backups, Vector and Search indexes, QStash schedules and messages, the
+DLQ, and logs. Installing the Upstash plugin registers the hosted server at
+`https://mcp.upstash.com/mcp`.
+
+Use the CLI when there is no MCP in the session, or when the work is inherently shell work — a CI
+step, a provisioning script, or piping JSON into other commands.
+
 The Upstash CLI (`upstash`) manages Upstash services via the Upstash Developer API. All commands are non-interactive and emit JSON on stdout. Errors go to stderr as `{ "error": "..." }` with exit code `1`.
 
 ## Install


### PR DESCRIPTION
Bundling the MCP into the plugins created a regression nothing accounted for. No skill mentions the Upstash MCP server at all — the only MCP references in the tree are the Box SDKs' unrelated "attach an MCP server to a box agent" feature. Meanwhile `upstash-cli` advertises itself for "creating, listing, renaming, or deleting Redis databases ... reading usage stats ... or automating any Upstash account operation", which is exactly what the MCP's tools do.

An agent asked to create a database therefore loaded the CLI skill and was sent to `npm i -g @upstash/cli`, `upstash login` and an API key, while an already authenticated tool sat unused in the same session.

- `skills/upstash-cli/SKILL.md` now opens with a "Prefer the MCP server when it is available" section, and keeps the CLI for the cases it genuinely wins — no MCP in the session, CI steps, provisioning scripts, piping JSON.
- Its description ends with the same preference, so the routing decision can be made before the skill is even loaded.
- `scripts/header.md` says it once more in the combined skill's preamble, which is what an agent reads when choosing a sub-skill.
- AGENTS.md records the ordering so future edits keep it.

The SDK skills are untouched: they are about writing application code, which the MCP does not do. `upstash-redis-start` is also untouched — it targets the case where the user has no credentials, so no MCP is available either.

Claude-Session: https://claude.ai/code/session_01FPx9e82XCTxDH1msNUAV1q