### PR TITLE
Correct the box CLI skill against a real session

### DIFF
--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -35,8 +35,8 @@ box use <box-id>                                       # pin one to this directo
 box status                                             # id, where it came from, state
 ```
 
-`--keep-alive`, `--browser` and `--env` can only be chosen at create time; to
-change any of them you make a new box.
+`--keep-alive`, `--browser`, `--env` and `--size` can only be chosen at create
+time; to change any of them you make a new box. There is no resize.
 
 Default to a plain `box create --no-repl`. A plain box pauses when it goes idle
 and resumes on the next command, which is what almost all work wants:
@@ -44,6 +44,7 @@ and resumes on the next command, which is what almost all work wants:
 ```bash
 box create --no-repl --browser             # provision a headless Chromium
 box create --no-repl --env KEY=VAL         # env for this box (repeatable)
+box create --no-repl --size medium         # small (default), medium, large
 ```
 
 Add `--keep-alive` only when something has to survive an idle gap: a detached
@@ -331,11 +332,13 @@ A property not named in `required` is optional. Nested objects are refused.
 
 ### Capturing straight into the box
 
-`box browser screenshot` writes to the machine running the CLI, so getting the
-image into the box costs an upload. Chromium's CDP is open on `127.0.0.1:9222`
-**from inside the box** with no token, so a script running there can capture and
-write in one step, and can do full-page and element-clipped captures that the
-CLI does not expose:
+`box browser screenshot --full-page -o page.png` is the short way, and it is
+enough whenever the image can live on this machine. It writes to the machine
+running the CLI, though, so getting the image into the box costs an upload.
+
+Chromium's CDP is open on `127.0.0.1:9222` **from inside the box** with no
+token, so a script running there captures and writes in one step, and can clip
+to a single element, which the CLI does not expose:
 
 Write the script with `box files write` rather than inlining it: the remote
 shell is `sh`, and quoting a program through `box exec` is where this goes
@@ -381,9 +384,9 @@ JS
 box exec -- 'node shot.mjs'      # shot.png is now in the box
 ```
 
-The `clip` is what makes this a full-page capture rather than a viewport one,
-and it is what the CLI does not expose. An element-clipped capture is the same
-call with that element's box as the clip. Node's global
+The `clip` is what makes this a full-page capture rather than a viewport one;
+`--full-page` does the same thing. An element-clipped capture is the same call
+with that element's box as the clip, and that one has no CLI flag. Node's global
 `fetch` and `WebSocket` are enough, so nothing has to be installed, but Chromium
 must have been started once by a `box browser` command first.
 
@@ -440,6 +443,46 @@ Both `box env set` and `box create --env` take the value as an argument, so a
 secret passed either way is visible in `ps` and lands in shell history. Neither
 is a secrets mechanism; keep real credentials out of both and use a token the
 box fetches for itself.
+
+## Flag reference
+
+The flags the walkthroughs above do not reach. Every command also takes the
+global `--box`, `--json` and `--token`.
+
+```bash
+box create --no-repl --git-user-name N --git-user-email E   # commit identity
+box create --no-repl --agent-api-key stored                 # key saved in the console
+box create --no-repl --no-use                               # do not write .box
+box init-demo --directory my-demo                           # scaffold elsewhere
+
+box exec -C /srv/app -- npm test         # -C/--cwd: working directory
+box run --timeout 600 -q "..."           # -q/--quiet: no tool-call logs on stderr
+box code --timeout 120 "..."             # both take --timeout in seconds
+
+box files read --offset 0 --length 65536 big.log   # a slice; 8 MiB per read
+box files read --encoding base64 logo.png          # binary out
+box files write --encoding base64 logo.png -       # binary in
+box files remove -r build/                         # -r required for a directory
+box files mkdir -p a/b/c                           # -p creates missing parents
+box files stat --follow link                       # resolve a final symlink
+
+box git clone --branch main --depth 1 <url>        # shallow, single branch
+box git clone --github-token $TOKEN <url>          # private repository
+box git commit -m "msg" --author-name N --author-email E
+box git push --branch feature/x                    # names the branch to push
+
+box public-url 3000 --bearer-token       # or --basic-auth; both generate credentials
+box use --unset                          # drop this directory's .box, never a parent's
+
+box schedule agent --cron "0 9 * * *" --model <m> --timeout 300 --webhook-url <url> "..."
+box schedule update <id> --timeout 0     # 0 clears the timeout; --prompt, --cron, --model too
+
+box config network custom --allow-domain a.test --allow-cidr 10.0.0.0/8 --deny-cidr 10.1.0.0/16
+box config harness --command my-agent --arg --verbose   # --arg repeatable, sent before the prompt
+```
+
+`-C` means the working directory on `box exec` (`--cwd`) and the repository
+directory on every `box git` and `box schedule` subcommand (`--folder`).
 
 ## Output
 

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -338,26 +338,43 @@ const targets = await (await fetch("http://127.0.0.1:9222/json")).json();
 const page = targets.find((t) => t.type === "page");
 const ws = new WebSocket(page.webSocketDebuggerUrl);
 await new Promise((r) => (ws.onopen = r));
-ws.send(JSON.stringify({
-  id: 1,
-  method: "Page.captureScreenshot",
-  params: { format: "png", captureBeyondViewport: true },
-}));
-const { data } = await new Promise((r) => {
-  ws.onmessage = (m) => {
-    const msg = JSON.parse(m.data);
-    if (msg.id === 1) r(msg.result);
-  };
+
+let id = 0;
+const pending = new Map();
+ws.onmessage = (m) => {
+  const msg = JSON.parse(m.data);
+  pending.get(msg.id)?.(msg.result);
+  pending.delete(msg.id);
+};
+const send = (method, params = {}) =>
+  new Promise((resolve) => {
+    const callId = ++id;
+    pending.set(callId, resolve);
+    ws.send(JSON.stringify({ id: callId, method, params }));
+  });
+
+// captureBeyondViewport only permits capture outside the viewport; the clip is
+// what makes it the whole page. cssContentSize is in CSS pixels, which is what
+// clip expects.
+const metrics = await send("Page.getLayoutMetrics");
+const size = metrics.cssContentSize ?? metrics.contentSize;
+const { data } = await send("Page.captureScreenshot", {
+  format: "png",
+  captureBeyondViewport: true,
+  clip: { x: 0, y: 0, width: size.width, height: size.height, scale: 1 },
 });
-await import("node:fs").then((fs) => fs.writeFileSync("shot.png", Buffer.from(data, "base64")));
+
+const fs = await import("node:fs");
+fs.writeFileSync("shot.png", Buffer.from(data, "base64"));
 ws.close();
 JS
 
 box exec -- 'node shot.mjs'      # shot.png is now in the box
 ```
 
-`captureBeyondViewport` is the full-page capture the CLI does not expose;
-element-clipped captures come from the same call with a `clip`. Node's global
+The `clip` is what makes this a full-page capture rather than a viewport one,
+and it is what the CLI does not expose. An element-clipped capture is the same
+call with that element's box as the clip. Node's global
 `fetch` and `WebSocket` are enough, so nothing has to be installed, but Chromium
 must have been started once by a `box browser` command first.
 

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -57,7 +57,10 @@ box create --no-repl --keep-alive                            # stays up when idl
 box create --no-repl --keep-alive --init-command "npm ci"    # startup script
 ```
 
-`--env` is per-box. `box env set` is account-level rather than per-box.
+`--env` is per-box. `box env set` is account-level: it is merged into every box
+created afterwards, never into one that already exists. A per-box `--env` wins
+for the same key, so account-level values only fill in what the box did not set.
+Account-level skills and MCP servers are merged the same way.
 
 `paused` is not an error; the next command resumes the box.
 
@@ -97,6 +100,13 @@ box exec --json -- node -e 'console.log(1)'   # {stdout, stderr, exit_code}
 The remote shell is `sh`, not bash. A heredoc inside `box exec` fails with
 `Syntax error: redirection unexpected`; write the file with `box files write - `
 instead, or wrap the command in `bash -c` when the box has bash.
+
+For an interactive shell, ssh straight in. The box id is the user and the Box
+API key is the password:
+
+```bash
+ssh <box-id>@us-east-1.box.upstash.com
+```
 
 Commands run as `boxuser`, so a global npm install needs sudo, which is
 passwordless:
@@ -303,6 +313,11 @@ box browser observe "what can I click here?"
 box browser live-url                    # a URL for a human to watch the tab
 ```
 
+Every `box browser act` is metered: it takes an instruction in words and needs
+a model to read the page. The SDK can replay an `observe()` result for free,
+but the CLI takes only the string form, so a loop of `act` calls costs a model
+call each time. `content`, `goto`, `screenshot` and `close` are not metered.
+
 Recordings, when you need to show what happened rather than describe it:
 
 ```bash
@@ -418,7 +433,7 @@ box skills add upstash-redis-js        # skills available to the box's agent
 box skills list
 box skills remove upstash-redis-js
 box config model anthropic/claude-sonnet-5
-box config init-command set "npm ci"   # runs when the box starts
+box config init-command set "npm ci"   # keep-alive boxes only; runs on start
 box config init-command get
 box config init-command delete
 box config network deny-all            # or allow-all, or custom

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -51,6 +51,11 @@ and the detached server in the example below dies with it. `--env` is per-box;
 
 `paused` is not an error; the next command resumes the box.
 
+A `.box` file is found by walking **up** from the working directory, so `cd`-ing
+into another project can silently pick up a pin left there earlier and run
+against the wrong box. In any session touching more than one box, pass `--box`
+explicitly; `box status` says which box it resolved and where that came from.
+
 Clean up when the work is done. Boxes cost money while they exist:
 
 ```bash
@@ -77,6 +82,17 @@ Put the remote command after `--`, or its flags are parsed as `box`'s own.
 box exec -- npm install
 box exec -C repo -- npm test
 box exec --json -- node -e 'console.log(1)'   # {stdout, stderr, exit_code}
+```
+
+The remote shell is `sh`, not bash. A heredoc inside `box exec` fails with
+`Syntax error: redirection unexpected`; write the file with `box files write - `
+instead, or wrap the command in `bash -c` when the box has bash.
+
+Commands run as `boxuser`, so a global npm install needs sudo, which is
+passwordless:
+
+```bash
+box exec -- 'sudo npm install -g @upstash/docs7'   # EACCES without sudo
 ```
 
 One argument is a shell expression, sent as written, so pipes and redirection work.
@@ -127,16 +143,21 @@ http.createServer((_, res) => {
 JS
 
 box exec -- '( node server.js > server.log 2>&1 & )'          # detached, or it dies
-box exec -- 'sleep 1; curl -sf localhost:3000 >/dev/null && echo up'
+box exec -- 'sleep 1; ss -ltn | grep -q "0.0.0.0:3000" && echo up'
 box public-url 3000                                           # the link to reply with
 ```
 
 Node's own `http` module rather than a package: no install, no network fetch, and it
 works on a bare `node` runtime.
 
-Check the port answers before publishing it. A public URL for a port nothing is
-listening on returns 502, which reads as a broken game rather than as a race with a
-server that had not finished starting.
+Check the port before publishing it, and check what it is **bound to**, not just
+that it answers. A server on `127.0.0.1` replies to a curl from inside the box
+and still cannot be published: the proxy reaches the container by address, so
+`box public-url` returns 502. That is why the check above greps for `0.0.0.0`
+rather than curling localhost, which passes in exactly the case that fails.
+
+Most dev servers need telling: `--host 0.0.0.0` for Vite and many others,
+`-H 0.0.0.0` for some, and a few cannot be moved off loopback at all.
 
 `--keep-alive` is what keeps the link working. Without it the box pauses when
 idle, the detached server dies with it, and the URL you handed over starts
@@ -252,9 +273,10 @@ takes the id, so a long agent run or build is interruptible from a fresh shell.
 
 ## Browser
 
-Only on a box created with `--browser`. This is the one part of a box `box exec`
-cannot reach, because Chromium is driven through the API rather than from inside
-the container.
+Only on a box created with `--browser`. Chromium **runs inside the box**, so it
+reaches your app on `http://localhost:3000` with no public URL involved. What
+lives outside is only the control path: you drive it through these commands
+rather than from a shell in the box, which is why `box exec` has no equivalent.
 
 ```bash
 box browser open https://example.com    # prints the tab id
@@ -279,6 +301,9 @@ box browser recordings get <recording-id>
 box browser recordings download <recording-id> -o session.mp4
 ```
 
+Chromium starts on first use, so the very first `box browser open` is slower
+than the rest, and anything talking to CDP directly fails until it has run once.
+
 `--tab <id>` is optional while one tab is open and required once there are
 several. `screenshot` writes to a file because stdout carries text, and that file
 lands on this machine rather than in the box. To put a screenshot on a pull request
@@ -292,6 +317,28 @@ box browser extract "the listed price" --schema s.json
 ```
 
 A property not named in `required` is optional. Nested objects are refused.
+
+### Capturing straight into the box
+
+`box browser screenshot` writes to the machine running the CLI, so getting the
+image into the box costs an upload. Chromium's CDP is open on `127.0.0.1:9222`
+**from inside the box** with no token, so a script running there can capture and
+write in one step, and can do full-page and element-clipped captures that the
+CLI does not expose:
+
+```bash
+box exec -- 'node -e "
+  const [t] = (await (await fetch(\"http://127.0.0.1:9222/json\")).json())
+    .filter((x) => x.type === \"page\");
+  // …open a WebSocket to t.webSocketDebuggerUrl, send Page.captureScreenshot,
+  // then write the base64 result to a file.
+"'
+```
+
+Node's global `fetch` and `WebSocket` are enough, so this needs nothing
+installed. Worth it only when you want the image to stay in the box or need a
+capture the CLI cannot make; otherwise `screenshot -o` and `files upload` is
+shorter.
 
 ## Schedules
 
@@ -330,6 +377,8 @@ this one:
 
 ```bash
 box env set KEY VAL                    # box create --env is per-box instead
+                                       # and the clean way to give a box a secret:
+                                       # it never appears in a command line
 box env list
 box env delete KEY
 box env set-all A=1 B=2                # replaces every var, does not merge

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -139,7 +139,7 @@ const http = require("http"), fs = require("fs");
 http.createServer((_, res) => {
   res.writeHead(200, { "Content-Type": "text/html" });
   res.end(fs.readFileSync("index.html"));
-}).listen(3000);
+}).listen(3000, "0.0.0.0");   // the default binds ::, which the check below misses
 JS
 
 box exec -- '( node server.js > server.log 2>&1 & )'          # detached, or it dies
@@ -275,8 +275,10 @@ takes the id, so a long agent run or build is interruptible from a fresh shell.
 
 Only on a box created with `--browser`. Chromium **runs inside the box**, so it
 reaches your app on `http://localhost:3000` with no public URL involved. What
-lives outside is only the control path: you drive it through these commands
-rather than from a shell in the box, which is why `box exec` has no equivalent.
+lives outside is only the control path: these commands reach Chromium through
+the API, so there is no `box exec` spelling of them. A script running in the box
+can still talk to Chromium directly over CDP, which is the escape hatch at the
+end of this section.
 
 ```bash
 box browser open https://example.com    # prints the tab id
@@ -326,18 +328,41 @@ image into the box costs an upload. Chromium's CDP is open on `127.0.0.1:9222`
 write in one step, and can do full-page and element-clipped captures that the
 CLI does not expose:
 
+Write the script with `box files write` rather than inlining it: the remote
+shell is `sh`, and quoting a program through `box exec` is where this goes
+wrong.
+
 ```bash
-box exec -- 'node -e "
-  const [t] = (await (await fetch(\"http://127.0.0.1:9222/json\")).json())
-    .filter((x) => x.type === \"page\");
-  // …open a WebSocket to t.webSocketDebuggerUrl, send Page.captureScreenshot,
-  // then write the base64 result to a file.
-"'
+box files write shot.mjs - <<'JS'
+const targets = await (await fetch("http://127.0.0.1:9222/json")).json();
+const page = targets.find((t) => t.type === "page");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => (ws.onopen = r));
+ws.send(JSON.stringify({
+  id: 1,
+  method: "Page.captureScreenshot",
+  params: { format: "png", captureBeyondViewport: true },
+}));
+const { data } = await new Promise((r) => {
+  ws.onmessage = (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id === 1) r(msg.result);
+  };
+});
+await import("node:fs").then((fs) => fs.writeFileSync("shot.png", Buffer.from(data, "base64")));
+ws.close();
+JS
+
+box exec -- 'node shot.mjs'      # shot.png is now in the box
 ```
 
-Node's global `fetch` and `WebSocket` are enough, so this needs nothing
-installed. Worth it only when you want the image to stay in the box or need a
-capture the CLI cannot make; otherwise `screenshot -o` and `files upload` is
+`captureBeyondViewport` is the full-page capture the CLI does not expose;
+element-clipped captures come from the same call with a `clip`. Node's global
+`fetch` and `WebSocket` are enough, so nothing has to be installed, but Chromium
+must have been started once by a `box browser` command first.
+
+This is only worth it when the image should stay in the box or you need a
+capture the CLI cannot make. Otherwise `screenshot -o` then `files upload` is
 shorter.
 
 ## Schedules
@@ -376,9 +401,7 @@ Account-level settings, which apply to boxes you create later rather than to
 this one:
 
 ```bash
-box env set KEY VAL                    # box create --env is per-box instead
-                                       # and the clean way to give a box a secret:
-                                       # it never appears in a command line
+box env set KEY VAL                    # applies to boxes created after this
 box env list
 box env delete KEY
 box env set-all A=1 B=2                # replaces every var, does not merge
@@ -386,6 +409,11 @@ box labels add staging                 # then: box list --label staging
 box labels list
 box labels remove staging
 ```
+
+Both `box env set` and `box create --env` take the value as an argument, so a
+secret passed either way is visible in `ps` and lands in shell history. Neither
+is a secrets mechanism; keep real credentials out of both and use a token the
+box fetches for itself.
 
 ## Output
 

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -57,6 +57,26 @@ box create --no-repl --keep-alive                            # stays up when idl
 box create --no-repl --keep-alive --init-command "npm ci"    # startup script
 ```
 
+The rest of the create-time options, all equally unchangeable afterwards:
+
+```bash
+box create --no-repl --skill upstash/skills/redis      # repeatable
+box create --no-repl --mcp docs=@org/mcp-server        # or name=https://url
+box create --no-repl --mcp-file servers.json           # for args and headers
+box create --no-repl --network-policy deny-all         # or allow-all, or custom
+box create --no-repl --network-policy custom --allow-domain api.example.com
+box create --no-repl --attach-headers-file headers.json
+```
+
+`--attach-headers-file` holds a JSON object keyed by host pattern
+(`{"api.stripe.com": {"Authorization": "Bearer ..."}}`), and those headers are
+injected into matching outbound requests from the box. There is an
+`--attach-header host:Name=value` form too, but the value lands in `ps` and in
+shell history, so prefer the file for anything secret.
+
+A skill id has three parts, `owner/repo/skill-name`. A malformed one is only
+warned about server-side, so the box comes up with the skill silently absent.
+
 `--env` is per-box. `box env set` is account-level: it is merged into every box
 created afterwards, never into one that already exists. A per-box `--env` wins
 for the same key, so account-level values only fill in what the box did not set.
@@ -201,7 +221,8 @@ box files mkdir -p a/b/c
 box files rename old.ts new.ts
 box files remove build -r                      # a directory needs -r
 box files upload ./local.zip /workspace/home/local.zip
-box files download repo
+box files download repo                        # a folder lands in ./repo
+box files download logs/app.log -o ./app.log   # a file; -o names the destination
 ```
 
 Write code with `-` and stdin. Passing source as an argument mangles it in the shell.
@@ -223,10 +244,14 @@ box git config -C repo --name "Bot" --email bot@example.com
 box git checkout -C repo feature/x             # creates the branch if missing
 box git exec -C repo -- add -A
 box git commit -C repo -m "message"
-box git push -C repo
+box git push -C repo                           # pushes the checked-out branch
 box git create-pr -C repo --title "Fix the thing" --base main
+box git create-pr -C repo --title "Fix the thing" --body-file notes.md
 box git create-issue -C repo --title "Search returns nothing"
 ```
+
+Use `--body-file` for anything longer than a sentence: a body worth writing does
+not survive shell quoting. `-` reads stdin.
 
 `box git exec` takes git's arguments without the leading `git`, and passes git's exit
 code through.

--- a/skills/upstash-box-cli/SKILL.md
+++ b/skills/upstash-box-cli/SKILL.md
@@ -36,18 +36,27 @@ box status                                             # id, where it came from,
 ```
 
 `--keep-alive`, `--browser` and `--env` can only be chosen at create time; to
-change any of them you make a new box:
+change any of them you make a new box.
+
+Default to a plain `box create --no-repl`. A plain box pauses when it goes idle
+and resumes on the next command, which is what almost all work wants:
 
 ```bash
-box create --no-repl --keep-alive          # do not auto-pause when idle
 box create --no-repl --browser             # provision a headless Chromium
 box create --no-repl --env KEY=VAL         # env for this box (repeatable)
-box create --no-repl --keep-alive --init-command "npm ci"   # startup script
 ```
 
-`--keep-alive` matters whenever you leave something running: an idle box pauses,
-and the detached server in the example below dies with it. `--env` is per-box;
-`box env` is account-level and applies to every box you create later.
+Add `--keep-alive` only when something has to survive an idle gap: a detached
+server you are about to reach over a preview URL, or a job that keeps running
+between commands. It stops the box pausing, so the box keeps costing money until
+you pause or delete it. `--init-command` is rejected without it:
+
+```bash
+box create --no-repl --keep-alive                            # stays up when idle
+box create --no-repl --keep-alive --init-command "npm ci"    # startup script
+```
+
+`--env` is per-box. `box env set` is account-level rather than per-box.
 
 `paused` is not an error; the next command resumes the box.
 

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -333,26 +333,43 @@ const targets = await (await fetch("http://127.0.0.1:9222/json")).json();
 const page = targets.find((t) => t.type === "page");
 const ws = new WebSocket(page.webSocketDebuggerUrl);
 await new Promise((r) => (ws.onopen = r));
-ws.send(JSON.stringify({
-  id: 1,
-  method: "Page.captureScreenshot",
-  params: { format: "png", captureBeyondViewport: true },
-}));
-const { data } = await new Promise((r) => {
-  ws.onmessage = (m) => {
-    const msg = JSON.parse(m.data);
-    if (msg.id === 1) r(msg.result);
-  };
+
+let id = 0;
+const pending = new Map();
+ws.onmessage = (m) => {
+  const msg = JSON.parse(m.data);
+  pending.get(msg.id)?.(msg.result);
+  pending.delete(msg.id);
+};
+const send = (method, params = {}) =>
+  new Promise((resolve) => {
+    const callId = ++id;
+    pending.set(callId, resolve);
+    ws.send(JSON.stringify({ id: callId, method, params }));
+  });
+
+// captureBeyondViewport only permits capture outside the viewport; the clip is
+// what makes it the whole page. cssContentSize is in CSS pixels, which is what
+// clip expects.
+const metrics = await send("Page.getLayoutMetrics");
+const size = metrics.cssContentSize ?? metrics.contentSize;
+const { data } = await send("Page.captureScreenshot", {
+  format: "png",
+  captureBeyondViewport: true,
+  clip: { x: 0, y: 0, width: size.width, height: size.height, scale: 1 },
 });
-await import("node:fs").then((fs) => fs.writeFileSync("shot.png", Buffer.from(data, "base64")));
+
+const fs = await import("node:fs");
+fs.writeFileSync("shot.png", Buffer.from(data, "base64"));
 ws.close();
 JS
 
 box exec -- 'node shot.mjs'      # shot.png is now in the box
 ```
 
-`captureBeyondViewport` is the full-page capture the CLI does not expose;
-element-clipped captures come from the same call with a `clip`. Node's global
+The `clip` is what makes this a full-page capture rather than a viewport one,
+and it is what the CLI does not expose. An element-clipped capture is the same
+call with that element's box as the clip. Node's global
 `fetch` and `WebSocket` are enough, so nothing has to be installed, but Chromium
 must have been started once by a `box browser` command first.
 

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -46,6 +46,11 @@ and the detached server in the example below dies with it. `--env` is per-box;
 
 `paused` is not an error; the next command resumes the box.
 
+A `.box` file is found by walking **up** from the working directory, so `cd`-ing
+into another project can silently pick up a pin left there earlier and run
+against the wrong box. In any session touching more than one box, pass `--box`
+explicitly; `box status` says which box it resolved and where that came from.
+
 Clean up when the work is done. Boxes cost money while they exist:
 
 ```bash
@@ -72,6 +77,17 @@ Put the remote command after `--`, or its flags are parsed as `box`'s own.
 box exec -- npm install
 box exec -C repo -- npm test
 box exec --json -- node -e 'console.log(1)'   # {stdout, stderr, exit_code}
+```
+
+The remote shell is `sh`, not bash. A heredoc inside `box exec` fails with
+`Syntax error: redirection unexpected`; write the file with `box files write - `
+instead, or wrap the command in `bash -c` when the box has bash.
+
+Commands run as `boxuser`, so a global npm install needs sudo, which is
+passwordless:
+
+```bash
+box exec -- 'sudo npm install -g @upstash/docs7'   # EACCES without sudo
 ```
 
 One argument is a shell expression, sent as written, so pipes and redirection work.
@@ -122,16 +138,21 @@ http.createServer((_, res) => {
 JS
 
 box exec -- '( node server.js > server.log 2>&1 & )'          # detached, or it dies
-box exec -- 'sleep 1; curl -sf localhost:3000 >/dev/null && echo up'
+box exec -- 'sleep 1; ss -ltn | grep -q "0.0.0.0:3000" && echo up'
 box public-url 3000                                           # the link to reply with
 ```
 
 Node's own `http` module rather than a package: no install, no network fetch, and it
 works on a bare `node` runtime.
 
-Check the port answers before publishing it. A public URL for a port nothing is
-listening on returns 502, which reads as a broken game rather than as a race with a
-server that had not finished starting.
+Check the port before publishing it, and check what it is **bound to**, not just
+that it answers. A server on `127.0.0.1` replies to a curl from inside the box
+and still cannot be published: the proxy reaches the container by address, so
+`box public-url` returns 502. That is why the check above greps for `0.0.0.0`
+rather than curling localhost, which passes in exactly the case that fails.
+
+Most dev servers need telling: `--host 0.0.0.0` for Vite and many others,
+`-H 0.0.0.0` for some, and a few cannot be moved off loopback at all.
 
 `--keep-alive` is what keeps the link working. Without it the box pauses when
 idle, the detached server dies with it, and the URL you handed over starts
@@ -247,9 +268,10 @@ takes the id, so a long agent run or build is interruptible from a fresh shell.
 
 ## Browser
 
-Only on a box created with `--browser`. This is the one part of a box `box exec`
-cannot reach, because Chromium is driven through the API rather than from inside
-the container.
+Only on a box created with `--browser`. Chromium **runs inside the box**, so it
+reaches your app on `http://localhost:3000` with no public URL involved. What
+lives outside is only the control path: you drive it through these commands
+rather than from a shell in the box, which is why `box exec` has no equivalent.
 
 ```bash
 box browser open https://example.com    # prints the tab id
@@ -274,6 +296,9 @@ box browser recordings get <recording-id>
 box browser recordings download <recording-id> -o session.mp4
 ```
 
+Chromium starts on first use, so the very first `box browser open` is slower
+than the rest, and anything talking to CDP directly fails until it has run once.
+
 `--tab <id>` is optional while one tab is open and required once there are
 several. `screenshot` writes to a file because stdout carries text, and that file
 lands on this machine rather than in the box. To put a screenshot on a pull request
@@ -287,6 +312,28 @@ box browser extract "the listed price" --schema s.json
 ```
 
 A property not named in `required` is optional. Nested objects are refused.
+
+### Capturing straight into the box
+
+`box browser screenshot` writes to the machine running the CLI, so getting the
+image into the box costs an upload. Chromium's CDP is open on `127.0.0.1:9222`
+**from inside the box** with no token, so a script running there can capture and
+write in one step, and can do full-page and element-clipped captures that the
+CLI does not expose:
+
+```bash
+box exec -- 'node -e "
+  const [t] = (await (await fetch(\"http://127.0.0.1:9222/json\")).json())
+    .filter((x) => x.type === \"page\");
+  // …open a WebSocket to t.webSocketDebuggerUrl, send Page.captureScreenshot,
+  // then write the base64 result to a file.
+"'
+```
+
+Node's global `fetch` and `WebSocket` are enough, so this needs nothing
+installed. Worth it only when you want the image to stay in the box or need a
+capture the CLI cannot make; otherwise `screenshot -o` and `files upload` is
+shorter.
 
 ## Schedules
 
@@ -325,6 +372,8 @@ this one:
 
 ```bash
 box env set KEY VAL                    # box create --env is per-box instead
+                                       # and the clean way to give a box a secret:
+                                       # it never appears in a command line
 box env list
 box env delete KEY
 box env set-all A=1 B=2                # replaces every var, does not merge

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -30,19 +30,32 @@ box use <box-id>                                       # pin one to this directo
 box status                                             # id, where it came from, state
 ```
 
-`--keep-alive`, `--browser` and `--env` can only be chosen at create time; to
-change any of them you make a new box:
+`--keep-alive`, `--browser`, `--env` and `--size` can only be chosen at create
+time; to change any of them you make a new box. There is no resize.
+
+Default to a plain `box create --no-repl`. A plain box pauses when it goes idle
+and resumes on the next command, which is what almost all work wants:
 
 ```bash
-box create --no-repl --keep-alive          # do not auto-pause when idle
 box create --no-repl --browser             # provision a headless Chromium
 box create --no-repl --env KEY=VAL         # env for this box (repeatable)
-box create --no-repl --keep-alive --init-command "npm ci"   # startup script
+box create --no-repl --size medium         # small (default), medium, large
 ```
 
-`--keep-alive` matters whenever you leave something running: an idle box pauses,
-and the detached server in the example below dies with it. `--env` is per-box;
-`box env` is account-level and applies to every box you create later.
+Add `--keep-alive` only when something has to survive an idle gap: a detached
+server you are about to reach over a preview URL, or a job that keeps running
+between commands. It stops the box pausing, so the box keeps costing money until
+you pause or delete it. `--init-command` is rejected without it:
+
+```bash
+box create --no-repl --keep-alive                            # stays up when idle
+box create --no-repl --keep-alive --init-command "npm ci"    # startup script
+```
+
+`--env` is per-box. `box env set` is account-level: it is merged into every box
+created afterwards, never into one that already exists. A per-box `--env` wins
+for the same key, so account-level values only fill in what the box did not set.
+Account-level skills and MCP servers are merged the same way.
 
 `paused` is not an error; the next command resumes the box.
 
@@ -82,6 +95,13 @@ box exec --json -- node -e 'console.log(1)'   # {stdout, stderr, exit_code}
 The remote shell is `sh`, not bash. A heredoc inside `box exec` fails with
 `Syntax error: redirection unexpected`; write the file with `box files write - `
 instead, or wrap the command in `bash -c` when the box has bash.
+
+For an interactive shell, ssh straight in. The box id is the user and the Box
+API key is the password:
+
+```bash
+ssh <box-id>@us-east-1.box.upstash.com
+```
 
 Commands run as `boxuser`, so a global npm install needs sudo, which is
 passwordless:
@@ -288,6 +308,11 @@ box browser observe "what can I click here?"
 box browser live-url                    # a URL for a human to watch the tab
 ```
 
+Every `box browser act` is metered: it takes an instruction in words and needs
+a model to read the page. The SDK can replay an `observe()` result for free,
+but the CLI takes only the string form, so a loop of `act` calls costs a model
+call each time. `content`, `goto`, `screenshot` and `close` are not metered.
+
 Recordings, when you need to show what happened rather than describe it:
 
 ```bash
@@ -317,11 +342,13 @@ A property not named in `required` is optional. Nested objects are refused.
 
 ### Capturing straight into the box
 
-`box browser screenshot` writes to the machine running the CLI, so getting the
-image into the box costs an upload. Chromium's CDP is open on `127.0.0.1:9222`
-**from inside the box** with no token, so a script running there can capture and
-write in one step, and can do full-page and element-clipped captures that the
-CLI does not expose:
+`box browser screenshot --full-page -o page.png` is the short way, and it is
+enough whenever the image can live on this machine. It writes to the machine
+running the CLI, though, so getting the image into the box costs an upload.
+
+Chromium's CDP is open on `127.0.0.1:9222` **from inside the box** with no
+token, so a script running there captures and writes in one step, and can clip
+to a single element, which the CLI does not expose:
 
 Write the script with `box files write` rather than inlining it: the remote
 shell is `sh`, and quoting a program through `box exec` is where this goes
@@ -367,9 +394,9 @@ JS
 box exec -- 'node shot.mjs'      # shot.png is now in the box
 ```
 
-The `clip` is what makes this a full-page capture rather than a viewport one,
-and it is what the CLI does not expose. An element-clipped capture is the same
-call with that element's box as the clip. Node's global
+The `clip` is what makes this a full-page capture rather than a viewport one;
+`--full-page` does the same thing. An element-clipped capture is the same call
+with that element's box as the clip, and that one has no CLI flag. Node's global
 `fetch` and `WebSocket` are enough, so nothing has to be installed, but Chromium
 must have been started once by a `box browser` command first.
 
@@ -401,7 +428,7 @@ box skills add upstash-redis-js        # skills available to the box's agent
 box skills list
 box skills remove upstash-redis-js
 box config model anthropic/claude-sonnet-5
-box config init-command set "npm ci"   # runs when the box starts
+box config init-command set "npm ci"   # keep-alive boxes only; runs on start
 box config init-command get
 box config init-command delete
 box config network deny-all            # or allow-all, or custom
@@ -426,6 +453,46 @@ Both `box env set` and `box create --env` take the value as an argument, so a
 secret passed either way is visible in `ps` and lands in shell history. Neither
 is a secrets mechanism; keep real credentials out of both and use a token the
 box fetches for itself.
+
+## Flag reference
+
+The flags the walkthroughs above do not reach. Every command also takes the
+global `--box`, `--json` and `--token`.
+
+```bash
+box create --no-repl --git-user-name N --git-user-email E   # commit identity
+box create --no-repl --agent-api-key stored                 # key saved in the console
+box create --no-repl --no-use                               # do not write .box
+box init-demo --directory my-demo                           # scaffold elsewhere
+
+box exec -C /srv/app -- npm test         # -C/--cwd: working directory
+box run --timeout 600 -q "..."           # -q/--quiet: no tool-call logs on stderr
+box code --timeout 120 "..."             # both take --timeout in seconds
+
+box files read --offset 0 --length 65536 big.log   # a slice; 8 MiB per read
+box files read --encoding base64 logo.png          # binary out
+box files write --encoding base64 logo.png -       # binary in
+box files remove -r build/                         # -r required for a directory
+box files mkdir -p a/b/c                           # -p creates missing parents
+box files stat --follow link                       # resolve a final symlink
+
+box git clone --branch main --depth 1 <url>        # shallow, single branch
+box git clone --github-token $TOKEN <url>          # private repository
+box git commit -m "msg" --author-name N --author-email E
+box git push --branch feature/x                    # names the branch to push
+
+box public-url 3000 --bearer-token       # or --basic-auth; both generate credentials
+box use --unset                          # drop this directory's .box, never a parent's
+
+box schedule agent --cron "0 9 * * *" --model <m> --timeout 300 --webhook-url <url> "..."
+box schedule update <id> --timeout 0     # 0 clears the timeout; --prompt, --cron, --model too
+
+box config network custom --allow-domain a.test --allow-cidr 10.0.0.0/8 --deny-cidr 10.1.0.0/16
+box config harness --command my-agent --arg --verbose   # --arg repeatable, sent before the prompt
+```
+
+`-C` means the working directory on `box exec` (`--cwd`) and the repository
+directory on every `box git` and `box schedule` subcommand (`--folder`).
 
 ## Output
 

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -52,6 +52,26 @@ box create --no-repl --keep-alive                            # stays up when idl
 box create --no-repl --keep-alive --init-command "npm ci"    # startup script
 ```
 
+The rest of the create-time options, all equally unchangeable afterwards:
+
+```bash
+box create --no-repl --skill upstash/skills/redis      # repeatable
+box create --no-repl --mcp docs=@org/mcp-server        # or name=https://url
+box create --no-repl --mcp-file servers.json           # for args and headers
+box create --no-repl --network-policy deny-all         # or allow-all, or custom
+box create --no-repl --network-policy custom --allow-domain api.example.com
+box create --no-repl --attach-headers-file headers.json
+```
+
+`--attach-headers-file` holds a JSON object keyed by host pattern
+(`{"api.stripe.com": {"Authorization": "Bearer ..."}}`), and those headers are
+injected into matching outbound requests from the box. There is an
+`--attach-header host:Name=value` form too, but the value lands in `ps` and in
+shell history, so prefer the file for anything secret.
+
+A skill id has three parts, `owner/repo/skill-name`. A malformed one is only
+warned about server-side, so the box comes up with the skill silently absent.
+
 `--env` is per-box. `box env set` is account-level: it is merged into every box
 created afterwards, never into one that already exists. A per-box `--env` wins
 for the same key, so account-level values only fill in what the box did not set.
@@ -196,7 +216,8 @@ box files mkdir -p a/b/c
 box files rename old.ts new.ts
 box files remove build -r                      # a directory needs -r
 box files upload ./local.zip /workspace/home/local.zip
-box files download repo
+box files download repo                        # a folder lands in ./repo
+box files download logs/app.log -o ./app.log   # a file; -o names the destination
 ```
 
 Write code with `-` and stdin. Passing source as an argument mangles it in the shell.
@@ -218,10 +239,14 @@ box git config -C repo --name "Bot" --email bot@example.com
 box git checkout -C repo feature/x             # creates the branch if missing
 box git exec -C repo -- add -A
 box git commit -C repo -m "message"
-box git push -C repo
+box git push -C repo                           # pushes the checked-out branch
 box git create-pr -C repo --title "Fix the thing" --base main
+box git create-pr -C repo --title "Fix the thing" --body-file notes.md
 box git create-issue -C repo --title "Search returns nothing"
 ```
+
+Use `--body-file` for anything longer than a sentence: a body worth writing does
+not survive shell quoting. `-` reads stdin.
 
 `box git exec` takes git's arguments without the leading `git`, and passes git's exit
 code through.

--- a/skills/upstash/upstash-box-cli/overview.md
+++ b/skills/upstash/upstash-box-cli/overview.md
@@ -134,7 +134,7 @@ const http = require("http"), fs = require("fs");
 http.createServer((_, res) => {
   res.writeHead(200, { "Content-Type": "text/html" });
   res.end(fs.readFileSync("index.html"));
-}).listen(3000);
+}).listen(3000, "0.0.0.0");   // the default binds ::, which the check below misses
 JS
 
 box exec -- '( node server.js > server.log 2>&1 & )'          # detached, or it dies
@@ -270,8 +270,10 @@ takes the id, so a long agent run or build is interruptible from a fresh shell.
 
 Only on a box created with `--browser`. Chromium **runs inside the box**, so it
 reaches your app on `http://localhost:3000` with no public URL involved. What
-lives outside is only the control path: you drive it through these commands
-rather than from a shell in the box, which is why `box exec` has no equivalent.
+lives outside is only the control path: these commands reach Chromium through
+the API, so there is no `box exec` spelling of them. A script running in the box
+can still talk to Chromium directly over CDP, which is the escape hatch at the
+end of this section.
 
 ```bash
 box browser open https://example.com    # prints the tab id
@@ -321,18 +323,41 @@ image into the box costs an upload. Chromium's CDP is open on `127.0.0.1:9222`
 write in one step, and can do full-page and element-clipped captures that the
 CLI does not expose:
 
+Write the script with `box files write` rather than inlining it: the remote
+shell is `sh`, and quoting a program through `box exec` is where this goes
+wrong.
+
 ```bash
-box exec -- 'node -e "
-  const [t] = (await (await fetch(\"http://127.0.0.1:9222/json\")).json())
-    .filter((x) => x.type === \"page\");
-  // …open a WebSocket to t.webSocketDebuggerUrl, send Page.captureScreenshot,
-  // then write the base64 result to a file.
-"'
+box files write shot.mjs - <<'JS'
+const targets = await (await fetch("http://127.0.0.1:9222/json")).json();
+const page = targets.find((t) => t.type === "page");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r) => (ws.onopen = r));
+ws.send(JSON.stringify({
+  id: 1,
+  method: "Page.captureScreenshot",
+  params: { format: "png", captureBeyondViewport: true },
+}));
+const { data } = await new Promise((r) => {
+  ws.onmessage = (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id === 1) r(msg.result);
+  };
+});
+await import("node:fs").then((fs) => fs.writeFileSync("shot.png", Buffer.from(data, "base64")));
+ws.close();
+JS
+
+box exec -- 'node shot.mjs'      # shot.png is now in the box
 ```
 
-Node's global `fetch` and `WebSocket` are enough, so this needs nothing
-installed. Worth it only when you want the image to stay in the box or need a
-capture the CLI cannot make; otherwise `screenshot -o` and `files upload` is
+`captureBeyondViewport` is the full-page capture the CLI does not expose;
+element-clipped captures come from the same call with a `clip`. Node's global
+`fetch` and `WebSocket` are enough, so nothing has to be installed, but Chromium
+must have been started once by a `box browser` command first.
+
+This is only worth it when the image should stay in the box or you need a
+capture the CLI cannot make. Otherwise `screenshot -o` then `files upload` is
 shorter.
 
 ## Schedules
@@ -371,9 +396,7 @@ Account-level settings, which apply to boxes you create later rather than to
 this one:
 
 ```bash
-box env set KEY VAL                    # box create --env is per-box instead
-                                       # and the clean way to give a box a secret:
-                                       # it never appears in a command line
+box env set KEY VAL                    # applies to boxes created after this
 box env list
 box env delete KEY
 box env set-all A=1 B=2                # replaces every var, does not merge
@@ -381,6 +404,11 @@ box labels add staging                 # then: box list --label staging
 box labels list
 box labels remove staging
 ```
+
+Both `box env set` and `box create --env` take the value as an argument, so a
+secret passed either way is visible in `ps` and lands in shell history. Neither
+is a secrets mechanism; keep real credentials out of both and use a token the
+box fetches for itself.
 
 ## Output
 


### PR DESCRIPTION
Seven corrections to the box CLI skill, each one something that cost time when an agent drove the CLI through a real task.

## The one that misdirected the whole first attempt

The browser section said `box exec` "cannot reach" Chromium. That is true of the control path and reads as network topology, so the first attempt went hunting for a public URL before discovering that `box browser goto http://localhost:3000` just works. **Chromium runs inside the box**; only the commands that drive it live outside.

## The readiness check that passed in the case that fails

The worked example curled `localhost:3000` before publishing. A server bound to `127.0.0.1` answers that curl from inside the box and still cannot be published, because the proxy reaches the container by address — so `box public-url` returns 502 and the check never fires. It now greps `ss` for `0.0.0.0`, and the prose names `--host 0.0.0.0`.

The example's own server had the same bug: `.listen(3000)` binds `::` on a dual-stack host, which the new check would have rejected. It binds `0.0.0.0` explicitly now.

## The rest

- **The remote shell is `sh`.** A heredoc inside `box exec` dies with `Syntax error: redirection unexpected`.
- **Commands run as `boxuser`**, so `npm i -g` needs the passwordless sudo.
- **`.box` files resolve by walking up**, so `cd`-ing into another project silently picks up a pin left there and runs against the wrong box.
- **Chromium starts lazily**, so anything using CDP fails until a `box browser` command has run once.
- **CDP is open on `127.0.0.1:9222` from inside the box**, which is how a script captures straight into the workspace, including the full-page and element-clipped captures the CLI does not expose.

`box env set` is documented as account-level, with a warning that neither it nor `create --env` is a secrets mechanism: both take the value as an argument, so it is visible in `ps` and lands in shell history.

## Notes

The CDP example is a complete script rather than a sketch, written with `box files write` rather than inlined through `box exec` — an agent will run whatever is in a skill, so a snippet ending in an ellipsis is worse than none. It clips to `Page.getLayoutMetrics().cssContentSize`, since `captureBeyondViewport` alone returns the viewport. It parses as an ES module but has not been executed against a live box.

Nothing from [box#239](https://github.com/upstash/box/pull/239) is documented here — those flags are not released, and documenting an unreleased CLI is the mistake this skill made once already.
