### PR TITLE
DX-3017: list Blob in the README and the MCP-first routing text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ The build's pre-check also refuses to run while `skills/upstash/` has unstaged c
 
 The plugins now install the hosted MCP server alongside the skills, so for
 account and data operations the agent usually has authenticated tools already
-in the session — creating and inspecting databases and indexes, running Redis
-commands, stats, logs, backups, QStash schedules and the DLQ. The CLI covers
+in the session — creating and inspecting databases, indexes and Blob buckets,
+running Redis commands, stats, logs, backups, QStash schedules and the DLQ. The CLI covers
 the same ground but needs a global npm install, a login and an API key.
 
 So `skills/upstash-cli/` opens by telling the agent to prefer the MCP when its

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Connect your AI coding agent to Upstash. This repo ships **skills** (per-SDK ins
 
 ## The Upstash agent surface
 
-- **Skills** — packaged instructions and CLI references for each Upstash SDK (Redis, QStash, Workflow, Vector, Search, Box, Ratelimit). No credentials needed. → [docs](https://upstash.com/docs/agent-resources/skills)
+- **Skills** — packaged instructions and CLI references for each Upstash SDK (Redis, QStash, Workflow, Vector, Search, Box, Blob, Ratelimit). No credentials needed. → [docs](https://upstash.com/docs/agent-resources/skills)
 - **MCP server** — live tools to query, debug, and manage your account. Two ways to run it:
   - **Remote (hosted)** — `https://mcp.upstash.com/mcp`, streamable HTTP, authenticated with OAuth (browser consent, on first use) or a developer API key header. Nothing to install.
   - **Local (stdio)** — [`@upstash/mcp-server`](https://www.npmjs.com/package/@upstash/mcp-server) run with `npx`, authenticated with your account email + a developer API key.

--- a/scripts/header.md
+++ b/scripts/header.md
@@ -12,6 +12,6 @@ metadata:
 This skill combines documentation for all Upstash SDKs. Pick the relevant sub-skill below.
 
 If Upstash MCP tools are available in this session, prefer them for account and data operations —
-creating and inspecting databases and indexes, running Redis commands, reading stats, logs and the
-DLQ. The sub-skills below are for writing application code; reach for `upstash-cli` only when there
+creating and inspecting databases, indexes and Blob buckets, running Redis commands, reading stats,
+logs and the DLQ. The sub-skills below are for writing application code; reach for `upstash-cli` only when there
 is no MCP or the work is inherently shell work.

--- a/skills/upstash-cli/SKILL.md
+++ b/skills/upstash-cli/SKILL.md
@@ -11,8 +11,8 @@ metadata:
 
 If Upstash MCP tools are in the session, call them instead of shelling out to the CLI. They are
 already authenticated and cover the same ground — creating and inspecting Redis databases, running
-Redis commands, usage stats, backups, Vector and Search indexes, QStash schedules and messages, the
-DLQ, and logs. Installing the Upstash plugin registers the hosted server at
+Redis commands, usage stats, backups, Vector and Search indexes, Blob buckets, QStash schedules and
+messages, the DLQ, and logs. Installing the Upstash plugin registers the hosted server at
 `https://mcp.upstash.com/mcp`.
 
 Use the CLI when there is no MCP in the session, or when the work is inherently shell work — a CI

--- a/skills/upstash/SKILL.md
+++ b/skills/upstash/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 This skill combines documentation for all Upstash SDKs. Pick the relevant sub-skill below.
 
 If Upstash MCP tools are available in this session, prefer them for account and data operations —
-creating and inspecting databases and indexes, running Redis commands, reading stats, logs and the
-DLQ. The sub-skills below are for writing application code; reach for `upstash-cli` only when there
+creating and inspecting databases, indexes and Blob buckets, running Redis commands, reading stats,
+logs and the DLQ. The sub-skills below are for writing application code; reach for `upstash-cli` only when there
 is no MCP or the work is inherently shell work.
 
 ## [upstash-blob-js](upstash-blob-js/overview.md)

--- a/skills/upstash/upstash-cli/overview.md
+++ b/skills/upstash/upstash-cli/overview.md
@@ -2,8 +2,8 @@
 
 If Upstash MCP tools are in the session, call them instead of shelling out to the CLI. They are
 already authenticated and cover the same ground — creating and inspecting Redis databases, running
-Redis commands, usage stats, backups, Vector and Search indexes, QStash schedules and messages, the
-DLQ, and logs. Installing the Upstash plugin registers the hosted server at
+Redis commands, usage stats, backups, Vector and Search indexes, Blob buckets, QStash schedules and
+messages, the DLQ, and logs. Installing the Upstash plugin registers the hosted server at
 `https://mcp.upstash.com/mcp`.
 
 Use the CLI when there is no MCP in the session, or when the work is inherently shell work — a CI


### PR DESCRIPTION
The `upstash-blob-js` skill, the CLI's `blob` commands, the manifests, `skills.sh.json` and the combined-skill header already landed under DX-2992 (last synced with `@upstash/blob` on Sep 7). I re-checked the skill against `upstash/blob-js@main` (exports, `Bucket` methods and options, the error-code list, the 16 MB multipart threshold) and `upstash/docs/blob` and found nothing stale, so this PR only closes the remaining gaps:

- **README** — the "Skills" bullet in *The Upstash agent surface* listed every SDK but Blob.
- **MCP-first routing** (`skills/upstash-cli/SKILL.md`, `scripts/header.md`, `AGENTS.md`) — the hosted MCP at `mcp.upstash.com/mcp` now exposes `blob_bucket` (list/create) and `blob_upload_url`, so Blob buckets are added to the list of things an agent should do through the MCP rather than the CLI.
- `skills/upstash/` regenerated with `npm run build`; `npm run check` passes.

Deliberately not changed:

- `zed-extension/extension.toml` — it runs the local `@upstash/mcp-server`, which has no Blob tools yet.
- The README's `?features=` list — I couldn't confirm whether the hosted server takes a `blob` feature key.
- Plugin `version` — no bump; these are wording changes.